### PR TITLE
DLSS-NR: dynamic chained model passes with per-pass overrides, plus an optional Chinese language pack

### DIFF
--- a/OptiScaler.ini
+++ b/OptiScaler.ini
@@ -1561,6 +1561,17 @@ ToggleKey=auto
 ; true or false - Default (auto) is false
 Enabled=auto
 
+; Sequential Neural Rendering layers on Direct3D 12 (including paths bridged to Direct3D 12).
+; 1 preserves single-pass behaviour. 2-3 are useful starting points; higher counts remain available
+; but multiply GPU work and can amplify artifacts. Minimum 1, with no artificial upper limit.
+; Default (auto) is 1. Native Vulkan continues to run one layer with the master settings below.
+Passes=1
+
+; true enables sparse per-layer overrides in [DlssNr.Pass1], [DlssNr.Pass2], ... on Direct3D 12.
+; false makes every layer use the master model controls below without deleting stored overrides.
+; true or false - Default (auto) is false
+IndividualPassSettings=false
+
 ; How far the frame moves toward the model's picture. Its answer is not added to the frame: it is a
 ; complete picture, rescaled so its luminance sits where the original says it should, and this blends
 ; between the two. 0 gives back exactly what the upscaler produced, 1 is the model's picture, and above
@@ -1610,9 +1621,9 @@ DebugView=auto
 ; true or false - Default (auto) is true
 AutoCapture=auto
 
-; Model controls. The preset is baked in when the model is created, so it needs a restart; the rest are
-; live. Presets and styles are undocumented, and the preset scale is not the same one super resolution
-; or ray reconstruction use.
+; Model controls. Preset selects the model when its instance is created; the remaining controls are
+; live. Direct3D 12 recreates affected layers when presets change. Presets and styles are undocumented,
+; and the preset scale is not the same one super resolution or ray reconstruction use.
 ; Default (auto) is 0
 Preset=auto
 Style=auto
@@ -1625,3 +1636,29 @@ LocalTone=auto
 SkinStructure=auto
 ; true or false - Default (auto) is true
 AutoMask=auto
+
+; Optional per-layer controls. Section numbers are one-based decimal integers; gaps are allowed.
+; A missing key, auto, or an invalid value inherits that key from [DlssNr], not from the previous layer.
+; Overrides for layers beyond Passes are kept when saving, so reducing Passes does not lose tuning.
+; Only the seven model controls shown here can be overridden. All other controls remain global.
+; Floats must be finite. Style and Preset accept unsigned 32-bit decimal or 0x-prefixed values.
+; Explicit values stay explicit even when equal to the master value. Remove a key or set it to auto
+; to resume inheritance; remove all keys/the section to clear a layer. No overrides apply on native Vulkan.
+;
+; Examples (commented out). Enable IndividualPassSettings above and uncomment only the desired keys:
+; [DlssNr.Pass1]
+; Intensity=1.0
+; LocalStructure=1.0
+; LocalTone=1.0
+; SkinStructure=-1.0
+; Style=0
+; Preset=0
+; AutoMask=true
+;
+; [DlssNr.Pass2]
+; Intensity=0.5
+; LocalTone=auto
+; SkinStructure=-1.0
+;
+; SkinStructure=-1 follows that layer's resolved LocalStructure (the model's own default).
+; AutoMask accepts true or false. Unspecified fields in each example still follow the master controls.

--- a/OptiScaler/Config.cpp
+++ b/OptiScaler/Config.cpp
@@ -9,6 +9,10 @@
 #include <misc/IdentifyGpu.h>
 
 #include <SimpleIni.h>
+#include <charconv>
+#include <cmath>
+#include <limits>
+#include <string_view>
 
 static CSimpleIniA ini;
 
@@ -30,20 +34,85 @@ static inline bool isInteger(const std::string& str, int& value)
 
 static inline bool isUInt(const std::string& str, uint32_t& value)
 {
-    std::istringstream iss(str);
-    return (iss >> value) && iss.eof();
+    std::string_view number(str);
+    if (number.starts_with('+'))
+        number.remove_prefix(1);
+
+    int base = 10;
+    if (number.starts_with("0x") || number.starts_with("0X"))
+    {
+        number.remove_prefix(2);
+        base = 16;
+    }
+
+    const auto [end, error] = std::from_chars(number.data(), number.data() + number.size(), value, base);
+    return error == std::errc() && end == number.data() + number.size();
 }
 
 static inline bool isFloat(const std::string& str, float& value)
 {
-    std::istringstream iss(str);
-    return (iss >> value) && iss.eof();
+    std::string_view number(str);
+    if (number.starts_with('+'))
+    {
+        number.remove_prefix(1);
+        if (number.starts_with('-'))
+            return false;
+    }
+
+    const auto [end, error] = std::from_chars(number.data(), number.data() + number.size(), value);
+    return error == std::errc() && end == number.data() + number.size() && std::isfinite(value);
+}
+
+static std::optional<uint32_t> DlssNrPassIndex(const char* section)
+{
+    constexpr std::string_view prefix = "DlssNr.Pass";
+    const std::string_view name(section);
+    if (name.size() <= prefix.size() || _strnicmp(name.data(), prefix.data(), prefix.size()) != 0)
+        return std::nullopt;
+
+    // Decimal, one-based section numbers; widen before subtracting so every map key round-trips.
+    uint64_t number = 0;
+    const auto [end, error] =
+        std::from_chars(name.data() + prefix.size(), name.data() + name.size(), number);
+    if (error != std::errc() || end != name.data() + name.size() || number == 0 ||
+        number > static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()) + 1)
+        return std::nullopt;
+
+    return static_cast<uint32_t>(number - 1);
 }
 
 Config::Config()
 {
     absoluteFileName = Util::DllPath().parent_path() / fileName;
     Reload(absoluteFileName);
+}
+
+DlssNrResolvedPassSettings Config::GetDlssNrPassSettings(uint32_t passIndex) const
+{
+    DlssNrResolvedPassSettings settings {
+        DlssNrIntensity.value_or_default(),      DlssNrLocalStructure.value_or_default(),
+        DlssNrLocalTone.value_or_default(),      DlssNrSkinStructure.value_or_default(),
+        DlssNrStyle.value_or_default(),          DlssNrPreset.value_or_default(),
+        DlssNrAutoMask.value_or_default()
+    };
+
+    if (!DlssNrIndividualPassSettings.value_or_default())
+        return settings;
+
+    const std::lock_guard lock(DlssNrPassOverridesMutex);
+    const auto pass = DlssNrPassOverrides.find(passIndex);
+    if (pass == DlssNrPassOverrides.end())
+        return settings;
+
+    const auto& overrides = pass->second;
+    settings.Intensity = overrides.Intensity.value_or(settings.Intensity);
+    settings.LocalStructure = overrides.LocalStructure.value_or(settings.LocalStructure);
+    settings.LocalTone = overrides.LocalTone.value_or(settings.LocalTone);
+    settings.SkinStructure = overrides.SkinStructure.value_or(settings.SkinStructure);
+    settings.Style = overrides.Style.value_or(settings.Style);
+    settings.Preset = overrides.Preset.value_or(settings.Preset);
+    settings.AutoMask = overrides.AutoMask.value_or(settings.AutoMask);
+    return settings;
 }
 
 bool Config::Reload(std::filesystem::path iniPath)
@@ -350,7 +419,9 @@ bool Config::Reload(std::filesystem::path iniPath)
                 DlssNrWhitePointSource = DlssNrWhitePointFromExposure.value() ? 1u : 0u;
             DlssNrScanMeter.set_from_config(readBool("DlssNr", "ScanMeter"));
             DlssNrScanTrim.set_from_config(readFloat("DlssNr", "ScanTrim"));
-            DlssNrPasses.set_from_config(readUInt("DlssNr", "Passes"));
+            DlssNrPasses.set_from_config(
+                readUInt("DlssNr", "Passes").transform([](uint32_t passes) { return std::max(1u, passes); }));
+            DlssNrIndividualPassSettings.set_from_config(readBool("DlssNr", "IndividualPassSettings"));
             DlssNrScanAnchorValue.set_from_config(readFloat("DlssNr", "ScanAnchorValue"));
             DlssNrScanAnchorWhitePoint.set_from_config(readFloat("DlssNr", "ScanAnchorWhitePoint"));
             DlssNrScanAnchors.set_from_config(readString("DlssNr", "ScanAnchors"));
@@ -365,6 +436,39 @@ bool Config::Reload(std::filesystem::path iniPath)
             DlssNrLocalTone.set_from_config(readFloat("DlssNr", "LocalTone"));
             DlssNrSkinStructure.set_from_config(readFloat("DlssNr", "SkinStructure"));
             DlssNrAutoMask.set_from_config(readBool("DlssNr", "AutoMask"));
+
+            // Enumerate the file, not 1..Passes: sparse, inactive and very high layer indices are valid.
+            CSimpleIniA::TNamesDepend passSections;
+            ini.GetAllSections(passSections);
+            passSections.sort(CSimpleIniA::Entry::LoadOrder());
+            for (const auto& section : passSections)
+            {
+                const auto passIndex = DlssNrPassIndex(section.pItem);
+                if (!passIndex)
+                    continue;
+
+                const auto intensity = readFloat(section.pItem, "Intensity");
+                const auto localStructure = readFloat(section.pItem, "LocalStructure");
+                const auto localTone = readFloat(section.pItem, "LocalTone");
+                const auto skinStructure = readFloat(section.pItem, "SkinStructure");
+                const auto style = readUInt(section.pItem, "Style");
+                const auto preset = readUInt(section.pItem, "Preset");
+                const auto autoMask = readBool(section.pItem, "AutoMask");
+                if (!intensity && !localStructure && !localTone && !skinStructure && !style && !preset && !autoMask)
+                    continue;
+
+                // Preserve the same first-config-wins precedence as the master settings on Reload.
+                const std::lock_guard lock(DlssNrPassOverridesMutex);
+                auto& overrides = DlssNrPassOverrides[*passIndex];
+                overrides.Intensity.set_from_config(intensity);
+                overrides.LocalStructure.set_from_config(localStructure);
+                overrides.LocalTone.set_from_config(localTone);
+                overrides.SkinStructure.set_from_config(skinStructure);
+                overrides.Style.set_from_config(style);
+                overrides.Preset.set_from_config(preset);
+                overrides.AutoMask.set_from_config(autoMask);
+            }
+
             DlssNrReversibleMode.set_from_config(readUInt("DlssNr", "ReversibleMode"));
             DlssNrApplyModel.set_from_config(readBool("DlssNr", "ApplyModel"));
             DlssNrHoldFrame.set_from_config(readBool("DlssNr", "HoldFrame"));
@@ -906,10 +1010,11 @@ template <typename T> std::string GetIntValue(std::optional<T> value, bool getHe
 
 std::string GetFloatValue(std::optional<float> value)
 {
-    if (!value.has_value())
+    if (!value.has_value() || !std::isfinite(value.value()))
         return "auto";
 
-    return std::to_string(value.value());
+    // Nine significant digits preserve every finite float, including small nonzero overrides.
+    return std::format("{:.{}g}", value.value(), std::numeric_limits<float>::max_digits10);
 }
 
 bool Config::SaveIni()
@@ -1240,7 +1345,11 @@ bool Config::SaveIni()
     ini.SetValue("DlssNr", "ScanAnchors", Instance()->DlssNrScanAnchors.value_for_config_or("").c_str());
     ini.SetValue("DlssNr", "ScanInverted", GetBoolValue(Instance()->DlssNrScanInverted.value_for_config()).c_str());
     ini.SetValue("DlssNr", "ScanMeter", GetBoolValue(Instance()->DlssNrScanMeter.value_for_config()).c_str());
-    ini.SetValue("DlssNr", "Passes", GetIntValue(Instance()->DlssNrPasses.value_for_config()).c_str());
+    ini.SetValue("DlssNr", "Passes",
+                 GetIntValue(Instance()->DlssNrPasses.value_for_config().transform(
+                                 [](uint32_t passes) { return std::max(1u, passes); })).c_str());
+    ini.SetValue("DlssNr", "IndividualPassSettings",
+                 Instance()->DlssNrIndividualPassSettings.value_for_config_or(false) ? "true" : "false");
     ini.SetValue("DlssNr", "UseProxy", GetBoolValue(Instance()->DlssNrUseProxy.value_for_config()).c_str());
     ini.SetValue("DlssNr", "ProxyProbe", GetBoolValue(Instance()->DlssNrProxyProbe.value_for_config()).c_str());
     // ScanExposure is a developer override with no menu control; persist it so a set ini keeps it.
@@ -1256,6 +1365,37 @@ bool Config::SaveIni()
     ini.SetValue("DlssNr", "SkinStructure",
                  GetFloatValue(Instance()->DlssNrSkinStructure.value_for_config()).c_str());
     ini.SetValue("DlssNr", "AutoMask", GetBoolValue(Instance()->DlssNrAutoMask.value_for_config()).c_str());
+    {
+        const std::lock_guard lock(DlssNrPassOverridesMutex);
+        // Rebuild this owned namespace so clearing a field/layer cannot resurrect stale keys,
+        // including alternate spellings such as Pass01. Inherited values are never materialised.
+        CSimpleIniA::TNamesDepend passSections;
+        ini.GetAllSections(passSections);
+        for (const auto& section : passSections)
+        {
+            if (DlssNrPassIndex(section.pItem))
+                ini.Delete(section.pItem, nullptr);
+        }
+
+        for (auto& [passIndex, overrides] : Instance()->DlssNrPassOverrides)
+        {
+            const auto section = std::format("DlssNr.Pass{}", static_cast<uint64_t>(passIndex) + 1);
+            if (auto value = overrides.Intensity.value_for_config(); value && std::isfinite(*value))
+                ini.SetValue(section.c_str(), "Intensity", GetFloatValue(value).c_str());
+            if (auto value = overrides.LocalStructure.value_for_config(); value && std::isfinite(*value))
+                ini.SetValue(section.c_str(), "LocalStructure", GetFloatValue(value).c_str());
+            if (auto value = overrides.LocalTone.value_for_config(); value && std::isfinite(*value))
+                ini.SetValue(section.c_str(), "LocalTone", GetFloatValue(value).c_str());
+            if (auto value = overrides.SkinStructure.value_for_config(); value && std::isfinite(*value))
+                ini.SetValue(section.c_str(), "SkinStructure", GetFloatValue(value).c_str());
+            if (auto value = overrides.Style.value_for_config())
+                ini.SetValue(section.c_str(), "Style", GetIntValue(value).c_str());
+            if (auto value = overrides.Preset.value_for_config())
+                ini.SetValue(section.c_str(), "Preset", GetIntValue(value).c_str());
+            if (auto value = overrides.AutoMask.value_for_config())
+                ini.SetValue(section.c_str(), "AutoMask", GetBoolValue(value).c_str());
+        }
+    }
     ini.SetValue("DlssNr", "ReversibleMode", GetIntValue(Instance()->DlssNrReversibleMode.value_for_config()).c_str());
     ini.SetValue("DlssNr", "ApplyModel", GetBoolValue(Instance()->DlssNrApplyModel.value_for_config()).c_str());
     ini.SetValue("DlssNr", "HoldFrame", GetBoolValue(Instance()->DlssNrHoldFrame.value_for_config()).c_str());
@@ -1805,29 +1945,12 @@ std::optional<std::wstring> Config::readWString(std::string section, std::string
 
 std::optional<float> Config::readFloat(std::string section, std::string key)
 {
-    auto value = readString(section, key);
+    const auto value = readString(section, key);
+    float result;
+    if (value && isFloat(*value, result))
+        return result;
 
-    try
-    {
-        float result;
-
-        if (value.has_value() && isFloat(value.value(), result))
-            return result;
-
-        return std::nullopt;
-    }
-    catch (const std::bad_optional_access&) // missing or auto value
-    {
-        return std::nullopt;
-    }
-    catch (const std::invalid_argument&) // invalid float string for std::stof
-    {
-        return std::nullopt;
-    }
-    catch (const std::out_of_range&) // out of range for 32 bit float
-    {
-        return std::nullopt;
-    }
+    return std::nullopt;
 }
 
 std::optional<int> Config::readInt(std::string section, std::string key)
@@ -1874,44 +1997,12 @@ std::optional<int> Config::readInt(std::string section, std::string key)
 
 std::optional<uint32_t> Config::readUInt(std::string section, std::string key)
 {
-    auto value = readString(section, key);
-    if (!value.has_value())
-        return std::nullopt;
+    const auto value = readString(section, key);
+    uint32_t result;
+    if (value && isUInt(*value, result))
+        return result;
 
-    const auto& s = *value;
-    try
-    {
-        size_t idx = 0;
-        int result;
-
-        // detect hex prefix
-        if (s.size() > 2 && (s[0] == '0') && (s[1] == 'x' || s[1] == 'X'))
-        {
-            result = std::stoi(s, &idx, 16);
-        }
-        else
-        {
-            result = std::stoi(s, &idx, 10);
-        }
-
-        // ensure we consumed the whole string
-        if (idx == s.size())
-            return result;
-        else
-            return std::nullopt;
-    }
-    catch (const std::bad_optional_access&) // missing or auto value
-    {
-        return std::nullopt;
-    }
-    catch (const std::invalid_argument&) // invalid float string for std::stof
-    {
-        return std::nullopt;
-    }
-    catch (const std::out_of_range&) // out// out of range for 32 bit float
-    {
-        return std::nullopt;
-    }
+    return std::nullopt;
 }
 
 std::optional<bool> Config::readBool(std::string section, std::string key)

--- a/OptiScaler/Config.h
+++ b/OptiScaler/Config.h
@@ -5,6 +5,8 @@
 
 #include <optional>
 #include <filesystem>
+#include <map>
+#include <mutex>
 
 enum HasDefaultValue
 {
@@ -143,6 +145,42 @@ template <class T, HasDefaultValue defaultState = WithDefault> class CustomOptio
         else
             return other;
     }
+};
+
+// An unset field inherits the corresponding master setting; explicit defaults stay explicit.
+struct DlssNrPassSettings
+{
+    CustomOptional<float, NoDefault> Intensity;
+    CustomOptional<float, NoDefault> LocalStructure;
+    CustomOptional<float, NoDefault> LocalTone;
+    CustomOptional<float, NoDefault> SkinStructure;
+    CustomOptional<uint32_t, NoDefault> Style;
+    CustomOptional<uint32_t, NoDefault> Preset;
+    CustomOptional<bool, NoDefault> AutoMask;
+
+    bool operator==(const DlssNrPassSettings& other) const
+    {
+        const auto equal = [](const auto& left, const auto& right)
+        {
+            return left.has_value() == right.has_value() && (!left.has_value() || *left == *right);
+        };
+        return equal(Intensity, other.Intensity) && equal(LocalStructure, other.LocalStructure) &&
+               equal(LocalTone, other.LocalTone) && equal(SkinStructure, other.SkinStructure) &&
+               equal(Style, other.Style) && equal(Preset, other.Preset) && equal(AutoMask, other.AutoMask);
+    }
+};
+
+struct DlssNrResolvedPassSettings
+{
+    float Intensity;
+    float LocalStructure;
+    float LocalTone;
+    float SkinStructure;
+    uint32_t Style;
+    uint32_t Preset;
+    bool AutoMask;
+
+    bool operator==(const DlssNrResolvedPassSettings&) const = default;
 };
 
 constexpr inline int UnboundKey = -1;
@@ -475,6 +513,14 @@ class Config
     // again -- so 8 costs eight times, near enough. There is no shortcut and no amortisation: the
     // passes are sequential and each one needs the last one's output.
     CustomOptional<uint32_t> DlssNrPasses { 1 };
+    CustomOptional<bool> DlssNrIndividualPassSettings { false };
+    // Zero-based indices, including inactive layers: reducing Passes never discards overrides.
+    std::map<uint32_t, DlssNrPassSettings> DlssNrPassOverrides;
+    // Direct map access must hold this mutex. Static storage preserves Config's copyability.
+    inline static std::mutex DlssNrPassOverridesMutex;
+
+    // Resolves inheritance without inserting into the map or allocating.
+    DlssNrResolvedPassSettings GetDlssNrPassSettings(uint32_t passIndex) const;
 
     // Which depth convention the model is told the guide uses.
     //

--- a/OptiScaler/OptiScaler.vcxproj
+++ b/OptiScaler/OptiScaler.vcxproj
@@ -384,6 +384,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClInclude Include="spoofing\User32_Spoofing.h" />
     <ClInclude Include="hooks\VulkanwDx12_Hooks.h" />
     <ClInclude Include="misc\IdentifyGpu.h" />
+    <ClInclude Include="misc\Localization.h" />
     <ClInclude Include="inputs\FSR2_Dx11.h" />
     <ClInclude Include="inputs\FSR2_Vk.h" />
     <ClInclude Include="inputs\XeSS_Dx11.h" />
@@ -645,6 +646,7 @@ copy NUL "$(SolutionDir)x64\Release\a\!! EXTRACT ALL FILES TO GAME FOLDER !!" /Y
     <ClCompile Include="menu\input\input_system_windows_hooks.cpp" />
     <ClCompile Include="menu\input\input_system_xinput.cpp" />
     <ClCompile Include="misc\IdentifyGpu.cpp" />
+    <ClCompile Include="misc\Localization.cpp" />
     <ClCompile Include="inputs\FSR2_Dx11.cpp" />
     <ClCompile Include="inputs\FSR2_Vk.cpp" />
     <ClCompile Include="inputs\XeSS_Dx11.cpp" />

--- a/OptiScaler/OptiScaler.vcxproj.filters
+++ b/OptiScaler/OptiScaler.vcxproj.filters
@@ -767,6 +767,9 @@
     <ClInclude Include="misc\IdentifyGpu.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="misc\Localization.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
     <ClInclude Include="shaders\hud_copy\precompile\HudCopy_Shader.h">
       <Filter>Header Files</Filter>
     </ClInclude>
@@ -1371,6 +1374,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="misc\IdentifyGpu.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="misc\Localization.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="framegen\dlssg\DLSSG_Dx12.cpp">

--- a/OptiScaler/dlssnr/DlssNrFeature_Dx12.h
+++ b/OptiScaler/dlssnr/DlssNrFeature_Dx12.h
@@ -87,6 +87,10 @@ CalibrationReading Calibration();
 // Whether the model is loaded and running, for the overlay.
 bool IsRunning();
 
+// Number of layers in the last successfully composed D3D12 frame. Zero while disabled, preparing
+// features, or unable to run; never the requested count before those layers have actually run.
+unsigned int ActivePassCount();
+
 // Why it is not, if it is not. Empty while it is running or has not been tried yet.
 const char* FailureReason();
 

--- a/OptiScaler/dlssnr/DlssNr_Menu.cpp
+++ b/OptiScaler/dlssnr/DlssNr_Menu.cpp
@@ -7,14 +7,18 @@
 
 #include <Config.h>
 #include <menu/menu_common.h>
+#include <misc/Localization.h>
 
 #include <imgui/imgui.h>
 
-#include <string>
+#include <limits>
 #include <unordered_map>
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <charconv>
+#include <cstring>
+#include <mutex>
 
 namespace DlssNr
 {
@@ -23,61 +27,350 @@ namespace DlssNr
 static void HelpMarker(const char* tip)
 {
     ImGui::SameLine();
-    ImGui::TextDisabled("(?)");
+    ImGui::TextDisabled(Tr("(?)"));
 
     if (ImGui::IsItemHovered())
     {
         ImGui::BeginTooltip();
         ImGui::PushTextWrapPos(ImGui::GetFontSize() * 40.0f);
-        ImGui::TextUnformatted(tip);
+        ImGui::TextUnformatted(Tr(tip));
         ImGui::PopTextWrapPos();
         ImGui::EndTooltip();
     }
 }
 
-// A slider that only writes its value when the handle is released.
-//
-// Some controls -- intensity, the structure and tone strengths -- are read by the model once, when
-// the feature is built, so changing one rebuilds the whole feature. Writing on every pixel of a drag
-// meant a rebuild per frame, felt as the picture hitching while you scrub. The slider still tracks
-// live under the cursor; only the commit that triggers the rebuild waits for release. Cheap controls
-// that are just shader constants (detail, colour, paper white) do not use this -- they can afford to
-// apply live.
+// Model settings rebuild features, so dragging only previews a value. The pending state belongs to
+// the actual ImGui widget ID, including its layer/field scopes, never to a shared display label.
+struct PendingSliderValue
+{
+    float value;
+    float original;
+    int frame;
+};
+
+static std::unordered_map<ImGuiID, PendingSliderValue> pendingSliders;
+
+static bool DeferredSliderValue(const char* label, float* value, float mn, float mx,
+                                const char* fmt = "%.2f")
+{
+    const ImGuiID id = ImGui::GetID(label);
+    const int frame = ImGui::GetFrameCount();
+    for (auto it = pendingSliders.begin(); it != pendingSliders.end();)
+    {
+        // Closing a panel or changing pages cancels an unfinished edit rather than replaying it
+        // when that widget eventually appears again.
+        if (it->second.frame < frame - 1)
+            it = pendingSliders.erase(it);
+        else
+            ++it;
+    }
+
+    auto pending = pendingSliders.find(id);
+    if (pending != pendingSliders.end() && pending->second.original != *value)
+    {
+        pendingSliders.erase(pending);
+        pending = pendingSliders.end();
+    }
+
+    float edited = pending != pendingSliders.end() ? pending->second.value : *value;
+    if (ImGui::SliderFloat(label, &edited, mn, mx, fmt) && std::isfinite(edited))
+        pendingSliders.insert_or_assign(id, PendingSliderValue { edited, *value, frame });
+
+    pending = pendingSliders.find(id);
+    if (ImGui::IsItemDeactivatedAfterEdit() && pending != pendingSliders.end())
+    {
+        *value = std::clamp(pending->second.value, mn, mx);
+        pendingSliders.erase(pending);
+        return true;
+    }
+
+    if (pending != pendingSliders.end())
+    {
+        if (ImGui::IsItemActive())
+            pending->second.frame = frame;
+        else
+            pendingSliders.erase(pending);
+    }
+    return false;
+}
+
+static void ClearDeferredSlider(const char* label)
+{
+    ImGui::PushID(label);
+    pendingSliders.erase(ImGui::GetID(Tr(label)));
+    ImGui::PopID();
+}
+
 static bool DeferredSlider(const char* label, CustomOptional<float>* opt, float mn, float mx,
                            float def, const char* fmt = "%.2f")
 {
-    static std::unordered_map<std::string, float> pending;
-
-    auto it = pending.find(label);
-    float value = it != pending.end() ? it->second : opt->value_or_default();
-    bool changed = false;
-
-    if (ImGui::SliderFloat(label, &value, mn, mx, fmt))
-        pending[label] = value;
-
-    if (ImGui::IsItemDeactivatedAfterEdit())
-    {
-        auto committed = pending.find(label);
-
-        if (committed != pending.end())
-        {
-            *opt = std::clamp(committed->second, mn, mx);
-            pending.erase(committed);
-            changed = true;
-        }
-    }
+    ImGui::PushID(label);
+    float value = opt->value_or_default();
+    bool changed = DeferredSliderValue(Tr(label), &value, mn, mx, fmt);
+    if (changed)
+        *opt = value;
 
     ImGui::SameLine();
-
-    const std::string resetId = std::string("Reset##") + label;
-    if (ImGui::SmallButton(resetId.c_str()))
+    if (ImGui::SmallButton(Tr("Reset")))
     {
         *opt = def;
-        pending.erase(std::string(label));   // drop any in-flight drag so the reset actually sticks
+        pendingSliders.erase(ImGui::GetID(Tr(label)));
         changed = true;
     }
-
+    ImGui::PopID();
     return changed;
+}
+
+template <class T>
+static bool UseMasterSetting(Config* config, uint32_t passIndex,
+                             CustomOptional<T, NoDefault> DlssNrPassSettings::* member)
+{
+    bool overridden;
+    {
+        const std::lock_guard lock(Config::DlssNrPassOverridesMutex);
+        const auto entry = config->DlssNrPassOverrides.find(passIndex);
+        overridden = entry != config->DlssNrPassOverrides.end() && (entry->second.*member).has_value();
+    }
+    ImGui::SameLine();
+    if (!overridden)
+    {
+        ImGui::TextDisabled(Tr("Inherited from master"));
+        return false;
+    }
+
+    if (!ImGui::SmallButton(Tr("Use master")))
+        return false;
+
+    {
+        const std::lock_guard lock(Config::DlssNrPassOverridesMutex);
+        const auto entry = config->DlssNrPassOverrides.find(passIndex);
+        if (entry != config->DlssNrPassOverrides.end())
+        {
+            entry->second.*member = std::optional<T> {};
+            if (entry->second == DlssNrPassSettings {})
+                config->DlssNrPassOverrides.erase(entry);
+        }
+    }
+    return true;
+}
+
+static void LayerSlider(Config* config, uint32_t passIndex, const char* label,
+                        CustomOptional<float, NoDefault> DlssNrPassSettings::* member,
+                        float value, float mn, float mx)
+{
+    ImGui::PushID(label);
+    if (DeferredSliderValue(Tr(label), &value, mn, mx))
+    {
+        const std::lock_guard lock(Config::DlssNrPassOverridesMutex);
+        config->DlssNrPassOverrides[passIndex].*member = value;
+    }
+    if (UseMasterSetting(config, passIndex, member))
+        pendingSliders.erase(ImGui::GetID(Tr(label)));
+    ImGui::PopID();
+}
+
+static void LayerCombo(Config* config, uint32_t passIndex, const char* label,
+                       CustomOptional<uint32_t, NoDefault> DlssNrPassSettings::* member,
+                       uint32_t value, const char* const* names, int count)
+{
+    ImGui::PushID(label);
+    int selected = static_cast<int>(std::min(value, static_cast<uint32_t>(count - 1)));
+    if (ImGui::Combo(Tr(label), &selected, names, count))
+    {
+        const std::lock_guard lock(Config::DlssNrPassOverridesMutex);
+        config->DlssNrPassOverrides[passIndex].*member = static_cast<uint32_t>(selected);
+    }
+    UseMasterSetting(config, passIndex, member);
+    ImGui::PopID();
+}
+
+struct DeferredIntegerState
+{
+    std::optional<uint32_t> pending;
+    uint32_t original = 0;
+    char input[32] {};
+    int frame = -1;
+    bool textEntry = false;
+    bool focusInput = false;
+    bool invalid = false;
+};
+
+static bool DeferredIntegerSlider(const char* label, uint32_t* value, uint32_t sliderMaximum,
+                                  uint32_t inputMaximum, DeferredIntegerState& edit)
+{
+    const int frame = ImGui::GetFrameCount();
+    if (edit.frame < frame - 1 ||
+        ((edit.pending.has_value() || edit.textEntry) && edit.original != *value))
+        edit = {};
+    edit.frame = frame;
+
+    if (edit.textEntry)
+    {
+        if (edit.focusInput)
+        {
+            ImGui::SetKeyboardFocusHere();
+            edit.focusInput = false;
+        }
+
+        const bool submitted = ImGui::InputText(Tr(label), edit.input, sizeof(edit.input),
+                                                ImGuiInputTextFlags_CharsDecimal |
+                                                    ImGuiInputTextFlags_AutoSelectAll |
+                                                    ImGuiInputTextFlags_EnterReturnsTrue);
+        if (ImGui::IsItemFocused() && ImGui::IsKeyPressed(ImGuiKey_Escape))
+        {
+            edit = {};
+            return false;
+        }
+        if (submitted || ImGui::IsItemDeactivated())
+        {
+            // ImGui's numeric text input uses scanf, which cannot reliably reject overflow. Parse
+            // directly into the configuration type: no signed narrowing, wrapping or partial input.
+            uint32_t parsed = 0;
+            const char* end = edit.input + std::strlen(edit.input);
+            const auto result = std::from_chars(edit.input, end, parsed);
+            edit.invalid = result.ec != std::errc {} || result.ptr != end || parsed == 0 ||
+                           parsed > inputMaximum;
+            if (!edit.invalid)
+            {
+                const bool changed = parsed != *value;
+                *value = parsed;
+                edit = {};
+                return changed;
+            }
+        }
+        if (edit.invalid)
+            ImGui::TextColored(ImVec4(1.0f, 0.6f, 0.3f, 1.0f),
+                               Tr("Enter a whole number from 1 to %u."), inputMaximum);
+        return false;
+    }
+
+    const uint32_t minimum = 1;
+    uint32_t edited = edit.pending.value_or(*value);
+    const uint32_t beforeClick = edited;
+    const bool changed = ImGui::SliderScalar(Tr(label), ImGuiDataType_U32, &edited, &minimum,
+                                             &sliderMaximum, "%u", ImGuiSliderFlags_NoInput);
+    if (ImGui::IsItemClicked() && ImGui::GetIO().KeyCtrl)
+    {
+        // Replace the slider with an integer entry on the next frame, never a second count control.
+        // Ignore the slider's mouse-position value on the Ctrl+click that requested text entry.
+        edit.pending.reset();
+        edit.original = *value;
+        edit.textEntry = true;
+        edit.focusInput = true;
+        edit.invalid = false;
+        snprintf(edit.input, sizeof(edit.input), "%u", beforeClick);
+        return false;
+    }
+    if (changed)
+    {
+        edit.pending = edited;
+        edit.original = *value;
+    }
+    if (ImGui::IsItemDeactivatedAfterEdit() && edit.pending.has_value())
+    {
+        const uint32_t committed = std::clamp(*edit.pending, minimum, inputMaximum);
+        const bool committedChange = committed != *value;
+        *value = committed;
+        edit = {};
+        return committedChange;
+    }
+    if (!ImGui::IsItemActive())
+        edit.pending.reset();
+    return false;
+}
+
+static void LayerCountSlider(Config* config)
+{
+    static DeferredIntegerState edit;
+    uint32_t value = std::max(1u, config->DlssNrPasses.value_or_default());
+    if (DeferredIntegerSlider("Passes (layers)", &value, 6,
+                              (std::numeric_limits<uint32_t>::max)(), edit))
+        config->DlssNrPasses = value;
+}
+
+static void RenderLayerSettings(Config* config, const char* const* presetNames, int presetCount,
+                                const char* const* styleNames, int styleCount)
+{
+    ImGui::SeparatorText(Tr("Individual layer settings"));
+    ImGui::TextWrapped(Tr("Unchanged fields follow the master settings. Use master clears only that "
+                         "field; use master for this layer clears all its overrides."));
+    ImGui::PushID("DlssNrPassOverrides");
+
+    // A typed count can be much larger than the slider range. Page the controls, not the cascade:
+    // rendering this menu must never enumerate or allocate one entry for every requested layer.
+    constexpr uint32_t pageSize = 8;
+    const uint32_t passes = std::max(1u, config->DlssNrPasses.value_or_default());
+    const uint32_t lastPage = (passes - 1) / pageSize;
+    static uint32_t page = 0;
+    page = std::min(page, lastPage);
+    if (lastPage != 0)
+    {
+        static DeferredIntegerState pageEdit;
+        uint32_t selectedPage = page + 1;
+        if (DeferredIntegerSlider("Layer page", &selectedPage, lastPage + 1, lastPage + 1, pageEdit))
+            page = selectedPage - 1;
+        HelpMarker("Only eight layer panels are shown at a time. This does not limit the number of "
+                   "rendering layers. Ctrl+click the page number to jump to a page.");
+    }
+
+    const uint32_t firstPass = page * pageSize;
+    const uint32_t shown = std::min(pageSize, passes - firstPass);
+    ImGui::TextDisabled(Tr("Layers %u-%u of %u"), firstPass + 1, firstPass + shown, passes);
+    for (uint32_t offset = 0; offset < shown; ++offset)
+    {
+        const uint32_t passIndex = firstPass + offset;
+        char layerId[11];
+        snprintf(layerId, sizeof(layerId), "%u", passIndex);
+        ImGui::PushID(layerId);
+        if (ImGui::TreeNodeEx("##LayerSettings", ImGuiTreeNodeFlags_None,
+                              Tr("Layer %u settings"), passIndex + 1))
+        {
+            bool overridden;
+            {
+                const std::lock_guard lock(Config::DlssNrPassOverridesMutex);
+                const auto entry = config->DlssNrPassOverrides.find(passIndex);
+                overridden = entry != config->DlssNrPassOverrides.end() && entry->second != DlssNrPassSettings {};
+            }
+            if (overridden && ImGui::SmallButton(Tr("Use master for this layer")))
+            {
+                {
+                    const std::lock_guard lock(Config::DlssNrPassOverridesMutex);
+                    config->DlssNrPassOverrides.erase(passIndex);
+                }
+                ClearDeferredSlider("Intensity");
+                ClearDeferredSlider("Local structure");
+                ClearDeferredSlider("Local tone");
+                ClearDeferredSlider("Skin structure");
+            }
+
+            const auto settings = config->GetDlssNrPassSettings(passIndex);
+            LayerCombo(config, passIndex, "Model preset", &DlssNrPassSettings::Preset,
+                       settings.Preset, presetNames, presetCount);
+            LayerCombo(config, passIndex, "Style", &DlssNrPassSettings::Style,
+                       settings.Style, styleNames, styleCount);
+            LayerSlider(config, passIndex, "Intensity", &DlssNrPassSettings::Intensity,
+                        settings.Intensity, 0.0f, 2.0f);
+            LayerSlider(config, passIndex, "Local structure", &DlssNrPassSettings::LocalStructure,
+                        settings.LocalStructure, 0.0f, 2.0f);
+            LayerSlider(config, passIndex, "Local tone", &DlssNrPassSettings::LocalTone,
+                        settings.LocalTone, 0.0f, 2.0f);
+            LayerSlider(config, passIndex, "Skin structure", &DlssNrPassSettings::SkinStructure,
+                        settings.SkinStructure, -1.0f, 2.0f);
+
+            ImGui::PushID("Auto skin mask");
+            bool autoMask = settings.AutoMask;
+            if (ImGui::Checkbox(Tr("Auto skin mask"), &autoMask))
+            {
+                const std::lock_guard lock(Config::DlssNrPassOverridesMutex);
+                config->DlssNrPassOverrides[passIndex].AutoMask = autoMask;
+            }
+            UseMasterSetting(config, passIndex, &DlssNrPassSettings::AutoMask);
+            ImGui::PopID();
+            ImGui::TreePop();
+        }
+        ImGui::PopID();
+    }
+    ImGui::PopID();
 }
 
 void RenderMenu(Config* config, float menuResScale)
@@ -85,13 +378,13 @@ void RenderMenu(Config* config, float menuResScale)
 
     // DLSS Neural Rendering -----------------------------
     ImGui::Spacing();
-    if (auto ch = ScopedCollapsingHeader("DLSS Neural Rendering"); ch.IsHeaderOpen())
+    if (auto ch = ScopedCollapsingHeader(Tr("DLSS Neural Rendering")); ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
         ImGui::Spacing();
 
         bool enabled = config->DlssNrEnabled.value_or_default();
-        if (ImGui::Checkbox("Enable Neural Rendering", &enabled))
+        if (ImGui::Checkbox(Tr("Enable Neural Rendering"), &enabled))
             config->DlssNrEnabled = enabled;
 
         HelpMarker("Synthesises detail in the upscaler's output, before frame generation sees it."
@@ -102,10 +395,10 @@ void RenderMenu(Config* config, float menuResScale)
 
         // The toggle can be bound to a key, and nobody would think to look for it under Keybinds
         // unless told. Dimmed, because it is a note rather than a setting.
-        ImGui::TextDisabled("Can be toggled with a key -- bind it under Keybinds, \"Neural Rendering\".");
+        ImGui::TextDisabled(Tr("Can be toggled with a key -- bind it under Keybinds, \"Neural Rendering\"."));
 
         bool applyModel = config->DlssNrApplyModel.value_or_default();
-        if (ImGui::Checkbox("Apply the model", &applyModel))
+        if (ImGui::Checkbox(Tr("Apply the model"), &applyModel))
             config->DlssNrApplyModel = applyModel;
 
         HelpMarker("Whether the model's edit is applied. Off shows the clean upscaler frame while the"
@@ -113,70 +406,84 @@ void RenderMenu(Config* config, float menuResScale)
                        "\nframe and toggle this to see the same frozen frame with and without Neural"
                        "\nRendering. Leave it on for normal use.");
 
-        // Either backend. The two keep separate state, and on a native Vulkan game the D3D12 side
-        // is never touched -- so asking only that one reports "waiting for the upscaler" over a pass
-        // that is demonstrably running.
-        const bool vulkan = DlssNr::IsRunningVk();
+        // Detect the API even while disabled or preparing. Vulkan-through-D3D12 uses the cascade;
+        // native Vulkan has its own status and continues to use one layer and the master settings.
+        const auto& state = State::Instance();
+        const bool nativeVulkan = state.api == API::Vulkan &&
+                                  (state.currentFeature == nullptr || !state.currentFeature->IsWithDx12());
+        const unsigned int activePasses = nativeVulkan ? 0 : DlssNr::ActivePassCount();
+        const char* reason = nativeVulkan ? DlssNr::FailureReasonVk() : DlssNr::FailureReason();
+        const bool running = nativeVulkan ? DlssNr::IsRunningVk() && DlssNr::FramesVk() != 0
+                                          : activePasses != 0;
 
-        // Turning the pass off does not release the model, so the feature handle stays alive and
-        // IsRunning keeps answering yes. Reporting a cost from that was wrong in the way that matters
-        // most: the toggle is how anyone A/Bs this, so the one moment the number is read is the one
-        // moment it describes the frame before last.
         if (!enabled)
         {
-            ImGui::TextDisabled("Off. The model stays loaded, so turning this back on is immediate.");
+            ImGui::TextDisabled(Tr("Idle: Neural Rendering is off."));
         }
-        else if (!DlssNr::IsRunning() && !vulkan)
+        else if (reason[0] != 0)
         {
-            const char* reason = DlssNr::FailureReason();
-
-            if (reason[0] != 0)
-            {
-                ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.35f, 1.0f), "Off for this session: %s.", reason);
-                ImGui::SameLine();
-
-                if (ImGui::SmallButton("Retry"))
-                    DlssNr::RetryAfterFailure();
-            }
-            else if (enabled)
-                ImGui::TextUnformatted("Waiting for the upscaler to run.");
+            ImGui::TextColored(ImVec4(1.0f, 0.4f, 0.35f, 1.0f),
+                               Tr("Neural Rendering could not run. The original image is shown."));
+            ImGui::TextWrapped(Tr("Reason: %s"), Tr(reason));
+            if (!nativeVulkan && ImGui::SmallButton(Tr("Retry")))
+                DlssNr::RetryAfterFailure();
+        }
+        else if (!running)
+        {
+            ImGui::TextWrapped(nativeVulkan
+                                  ? Tr("Preparing one-layer native Vulkan rendering; waiting for an upscaled frame.")
+                                  : Tr("Preparing Neural Rendering; waiting for an upscaled frame."));
         }
         else
         {
-            // The cost belongs here rather than only in the upscaler's breakdown: that tooltip needs
-            // OptiScaler's own upscaler to have run, and with native DLSS passing through there is
-            // nothing in it to hang this off.
-            // Either backend's timer. They measure the same thing by different means, and only one
-            // of them is running.
-            const auto ms = vulkan ? DlssNr::LastGpuTimeVk() : DlssNr::LastGpuTime();
-
-            // With "Apply the model" off the pass STILL RUNS (so Hold-frame A/B can toggle its edit on
-            // a frozen frame) -- it only outputs the clean frame. So the cost is real, and saying so
-            // stops the reading looking like a bug. Enable Neural Rendering off is what zeroes it.
-            const char* runSuffix =
-                !config->DlssNrApplyModel.value_or_default() ? "  (model running, edit hidden)" : "";
-
-            if (ms.has_value())
-                ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.5f, 1.0f), "Running%s - %.2f ms per frame%s",
-                                   vulkan ? " natively on Vulkan" : "", ms.value(), runSuffix);
-            else if (vulkan)
-                // Measured but not yet read: the first few frames are still in the query ring.
-                ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.5f, 1.0f), "Running natively on Vulkan - %llu frames%s",
-                                   DlssNr::FramesVk(), runSuffix);
+            const auto ms = nativeVulkan ? DlssNr::LastGpuTimeVk() : DlssNr::LastGpuTime();
+            if (nativeVulkan)
+            {
+                if (ms.has_value())
+                    ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.5f, 1.0f),
+                                       Tr("Running: 1 layer on native Vulkan - %.2f ms per frame"), ms.value());
+                else
+                    ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.5f, 1.0f),
+                                       Tr("Running: 1 layer on native Vulkan"));
+            }
+            else if (ms.has_value())
+                ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.5f, 1.0f),
+                                   Tr("Running: %u layer(s) - %.2f ms per frame"), activePasses, ms.value());
             else
-                ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.5f, 1.0f), "Running.%s", runSuffix);
+                ImGui::TextColored(ImVec4(0.4f, 0.9f, 0.5f, 1.0f),
+                                   Tr("Running: %u layer(s)"), activePasses);
 
-            ImGui::SameLine();
-            ImGui::TextDisabled("(?)");
-            if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-                ImGui::SetTooltip("The whole pass: the staging copies and the resolve as well as the"
-                                  "\nmodel. Timing only the model would flatter the number."
-                                  "\n\nCompare it against the frame time at the bottom of this window to"
-                                  "\nsee what it is costing you.");
+            HelpMarker("The whole cascade: every model layer, the staging copies and the final "
+                       "composition. Compare this with the frame time at the bottom of the window "
+                       "to see the performance cost.");
+            if (!applyModel)
+                ImGui::TextDisabled(Tr("The model is running, but its edit is hidden."));
         }
 
         ImGui::Spacing();
         ImGui::PushItemWidth(220.0f * menuResScale);
+
+        bool individualSettings = config->DlssNrIndividualPassSettings.value_or_default();
+        if (nativeVulkan)
+        {
+            ImGui::TextWrapped(Tr("Native Vulkan uses one layer and the master settings. Multiple layers "
+                                 "and individual layer settings require D3D12, including D3D12 bridges."));
+        }
+        else
+        {
+            LayerCountSlider(config);
+            HelpMarker("Stacks Neural Rendering layers in sequence. 1 is the original single-layer "
+                       "baseline; 2-3 is recommended. Higher counts cost more GPU time and memory and "
+                       "can amplify artifacts. Ctrl+click to type a higher layer count. Changes apply "
+                       "when you finish editing.");
+            ImGui::TextDisabled(Tr("1: baseline | 2-3: recommended | Higher: heavier GPU and memory use"));
+
+            if (ImGui::Checkbox(Tr("Individual layer settings"), &individualSettings))
+                config->DlssNrIndividualPassSettings = individualSettings;
+            HelpMarker("Off by default: every layer uses the master settings. Enable to override "
+                       "selected fields for each layer. Turning this off keeps your overrides but "
+                       "does not apply them.");
+        }
 
         // Any percentage, rather than a handful of steps somebody chose in advance. The lower bound
         // is 25%: below that the model is working on so little of the picture that its answer no
@@ -193,7 +500,7 @@ void RenderMenu(Config* config, float menuResScale)
                                ? pendingScale
                                : (int) lroundf(config->DlssNrWorkingScale.value_or_default() * 100.0f);
 
-        if (ImGui::SliderInt("Model resolution", &scalePercent, 25, 200, "%d%%"))
+        if (ImGui::SliderInt(Tr("Model resolution"), &scalePercent, 25, 200, "%d%%"))
             pendingScale = scalePercent;
 
         if (ImGui::IsItemDeactivatedAfterEdit() && pendingScale >= 0)
@@ -203,19 +510,19 @@ void RenderMenu(Config* config, float menuResScale)
         }
 
         if (scalePercent > 100)
-            ImGui::TextDisabled("Supersampling %.2fx: the model runs ABOVE native, then\n"
-                                "is sampled back down. Experimental, and costly -- time grows with the area.",
+            ImGui::TextDisabled(Tr("Supersampling %.2fx: the model runs ABOVE native, then\n"
+                                  "is sampled back down. Experimental, and costly -- time grows with the area."),
                                 scalePercent / 100.0f);
 
         if (scalePercent > 100)
         {
-            static const char* dsNames[] = { "FSR1", "Bicubic", "Catmull-Rom", "Lanczos2",
-                                             "Lanczos3", "Kaiser2", "Kaiser3", "MAGIC" };
+            static const char* dsNames[] = { Tr("FSR1"), Tr("Bicubic"), Tr("Catmull-Rom"), Tr("Lanczos2"),
+                                             Tr("Lanczos3"), Tr("Kaiser2"), Tr("Kaiser3"), Tr("MAGIC") };
             int ds = (int) config->DlssNrScalingDownscaler.value_or_default();
             if (ds < 0 || ds >= IM_ARRAYSIZE(dsNames))
                 ds = (int) Scaler::Lanczos3;
 
-            if (ImGui::Combo("Downscaler (NR)", &ds, dsNames, IM_ARRAYSIZE(dsNames)))
+            if (ImGui::Combo(Tr("Downscaler (NR)"), &ds, dsNames, IM_ARRAYSIZE(dsNames)))
                 config->DlssNrScalingDownscaler = (Scaler) ds;
 
             HelpMarker("The filter that averages the model's above-native answer back to display size --"
@@ -244,10 +551,10 @@ void RenderMenu(Config* config, float menuResScale)
             if (!reduced)
                 ImGui::BeginDisabled();
 
-            static const char* enlargeNames[] = { "Classic", "Matched residual" };
+            static const char* enlargeNames[] = { Tr("Classic"), Tr("Matched residual") };
             int enlarge = config->DlssNrTransfer.value_or_default() == 1 ? 1 : 0;
 
-            if (ImGui::Combo("Enlargement", &enlarge, enlargeNames, IM_ARRAYSIZE(enlargeNames)))
+            if (ImGui::Combo(Tr("Enlargement"), &enlarge, enlargeNames, IM_ARRAYSIZE(enlargeNames)))
                 config->DlssNrTransfer = (uint32_t) enlarge;
 
             if (!reduced)
@@ -267,14 +574,14 @@ void RenderMenu(Config* config, float menuResScale)
                        "\n\nFrom hhkbble's multi-pass work on this fork.");
         }
 
-        ImGui::SeparatorText("How much of it lands");
+        ImGui::SeparatorText(Tr("How much of it lands"));
 
         float transfer = config->DlssNrTransferStrength.value_or_default();
-        if (ImGui::SliderFloat("Detail strength", &transfer, 0.0f, 2.0f, "%.2f"))
+        if (ImGui::SliderFloat(Tr("Detail strength"), &transfer, 0.0f, 2.0f, "%.2f"))
             config->DlssNrTransferStrength = transfer;
 
         ImGui::SameLine();
-        if (ImGui::SmallButton("Reset##detail"))
+        if (ImGui::SmallButton(Tr("Reset##detail")))
             config->DlssNrTransferStrength = 1.0f;
 
         HelpMarker("How far the frame moves toward the model's picture."
@@ -289,11 +596,11 @@ void RenderMenu(Config* config, float menuResScale)
                        "\nand it decides what to do with it.");
 
         float colour = config->DlssNrColourStrength.value_or_default();
-        if (ImGui::SliderFloat("Colour strength", &colour, 0.0f, 4.0f, "%.2f"))
+        if (ImGui::SliderFloat(Tr("Colour strength"), &colour, 0.0f, 4.0f, "%.2f"))
             config->DlssNrColourStrength = colour;
 
         ImGui::SameLine();
-        if (ImGui::SmallButton("Reset##colour"))
+        if (ImGui::SmallButton(Tr("Reset##colour")))
             config->DlssNrColourStrength = 1.0f;
 
         HelpMarker("Whether the model's colour arrives with its light."
@@ -310,13 +617,13 @@ void RenderMenu(Config* config, float menuResScale)
 
         // Experimental. 0 off (soft knee), 1 Neutwo + our composition, 2 Neutwo + pure-inverse replace,
         // 3 hybrid+composed, 4 hybrid+replace (identity midtones + unclipped highlights). Always shown.
-        static const char* reversibleNames[] = { "Off (soft knee)", "Neutwo proxy + composed",
-                                                 "Neutwo proxy + replace", "Hybrid proxy + composed",
-                                                 "Hybrid proxy + replace" };
+        static const char* reversibleNames[] = { Tr("Off (soft knee)"), Tr("Neutwo proxy + composed"),
+                                                 Tr("Neutwo proxy + replace"), Tr("Hybrid proxy + composed"),
+                                                 Tr("Hybrid proxy + replace") };
         int reversible = (int) config->DlssNrReversibleMode.value_or_default();
         if (reversible < 0 || reversible > 4)
             reversible = 0;
-        if (ImGui::Combo("Reversible proxy (experimental)", &reversible, reversibleNames,
+        if (ImGui::Combo(Tr("Reversible proxy (experimental)"), &reversible, reversibleNames,
                          IM_ARRAYSIZE(reversibleNames)))
             config->DlssNrReversibleMode = (uint32_t) reversible;
 
@@ -340,26 +647,27 @@ void RenderMenu(Config* config, float menuResScale)
                        "\nstable. If you love the Replace look but the flicker bothers you, use this."
                        "\n\nOff is byte-identical to before.");
 
-        ImGui::SeparatorText("Model");
+        ImGui::SeparatorText(Tr("Model (master settings)"));
 
-        ImGui::TextUnformatted("Read when the model is built, so a change rebuilds it after a moment.");
+        ImGui::TextUnformatted(Tr("Read when the model is built, so a change rebuilds it after a moment."));
+        if (!nativeVulkan && individualSettings)
+            ImGui::TextWrapped(Tr("Shared by every layer unless that field has an individual override."));
+        ImGui::PushID("DlssNrMasterSettings");
 
-        static const char* nrPresetNames[] = { "Default", "Preset 1", "Preset 2", "Preset 3" };
-        int preset = (int) config->DlssNrPreset.value_or_default();
-        if (ImGui::Combo("Model preset", &preset, nrPresetNames, IM_ARRAYSIZE(nrPresetNames)))
+        static const char* nrPresetNames[] = { Tr("Default"), Tr("Preset 1"), Tr("Preset 2"), Tr("Preset 3") };
+        int preset = static_cast<int>(std::min(config->DlssNrPreset.value_or_default(), 3u));
+        if (ImGui::Combo(Tr("Model preset"), &preset, nrPresetNames, IM_ARRAYSIZE(nrPresetNames)))
             config->DlssNrPreset = (uint32_t) preset;
 
         HelpMarker("Default leaves the choice to the model."
                        "\n\nNot the same scale as the super resolution or ray reconstruction presets --"
                        "\nthe same number means something different here.");
 
-        static const char* nrStyleNames[] = { "Default (standard)", "Natural", "Cinematic" };
-        int style = (int) config->DlssNrStyle.value_or_default();
+        static const char* nrStyleNames[] = { Tr("Default (standard)"), Tr("Natural"), Tr("Cinematic") };
+        int style = static_cast<int>(std::min(config->DlssNrStyle.value_or_default(), 2u));
 
-        if (style > 2)
-            style = 2;
 
-        if (ImGui::Combo("Style", &style, nrStyleNames, IM_ARRAYSIZE(nrStyleNames)))
+        if (ImGui::Combo(Tr("Style"), &style, nrStyleNames, IM_ARRAYSIZE(nrStyleNames)))
             config->DlssNrStyle = (uint32_t) style;
 
         HelpMarker("The model's own processing profiles."
@@ -388,17 +696,22 @@ void RenderMenu(Config* config, float menuResScale)
                        "\nstrength of zero. 0 and above set skin independently of the rest of the frame.");
 
         bool autoMask = config->DlssNrAutoMask.value_or_default();
-        if (ImGui::Checkbox("Auto skin mask", &autoMask))
+        if (ImGui::Checkbox(Tr("Auto skin mask"), &autoMask))
             config->DlssNrAutoMask = autoMask;
 
         HelpMarker("Lets the model find skin itself rather than treating the frame uniformly.");
+        ImGui::PopID();
 
-        ImGui::SeparatorText("Colour");
+        if (!nativeVulkan && individualSettings)
+            RenderLayerSettings(config, nrPresetNames, IM_ARRAYSIZE(nrPresetNames),
+                                nrStyleNames, IM_ARRAYSIZE(nrStyleNames));
 
-        ImGui::TextDisabled("The model was trained on finished, sRGB-encoded frames. The upscaler's\n"
-                            "output is not one: it is linear and open-ended. These decide how it is\n"
-                            "mapped into something the model recognises. A frame the game reports as\n"
-                            "already tone-mapped is passed over untouched and none of this applies.");
+        ImGui::SeparatorText(Tr("Colour"));
+
+        ImGui::TextDisabled(Tr("The model was trained on finished, sRGB-encoded frames. The upscaler's\n"
+                              "output is not one: it is linear and open-ended. These decide how it is\n"
+                              "mapped into something the model recognises. A frame the game reports as\n"
+                              "already tone-mapped is passed over untouched and none of this applies."));
 
         {
         // Logarithmic, because the useful range is not linear. A quarter to 240: the low end because
@@ -426,15 +739,15 @@ void RenderMenu(Config* config, float menuResScale)
             const float anchorNow = DlssNr::ExposureScan::BestValue();
             const bool haveAnchor = !DlssNr::ExposureScan::Anchors().empty();
 
-            static const char* sourceNames[] = { "Paper white only", "The game's own exposure",
-                                                 "A buffer the scan found" };
+            static const char* sourceNames[] = { Tr("Paper white only"), Tr("The game's own exposure"),
+                                                 Tr("A buffer the scan found") };
 
             int source = (int) config->DlssNrWhitePointSource.value_or_default();
 
             if (source < 0 || source > 2)
                 source = 0;
 
-            if (ImGui::Combo("White point from", &source, sourceNames, IM_ARRAYSIZE(sourceNames)))
+            if (ImGui::Combo(Tr("White point from"), &source, sourceNames, IM_ARRAYSIZE(sourceNames)))
             {
                 config->DlssNrWhitePointSource = (uint32_t) source;
 
@@ -461,25 +774,25 @@ void RenderMenu(Config* config, float menuResScale)
             if (source == 1)
             {
                 if (!vk && ex.seenFrames == 0)
-                    ImGui::TextDisabled("Waiting for a frame...");
+                    ImGui::TextDisabled(Tr("Waiting for a frame..."));
                 else if (!haveExposure)
                     ImGui::TextColored(ImVec4(0.9f, 0.6f, 0.25f, 1.0f),
-                                       "This game supplies no exposure -- paper white is in use. Try "
-                                       "the scan instead.");
+                                       Tr("This game supplies no exposure -- paper white is in use. Try "
+                                          "the scan instead."));
                 else if (vk)
                     ImGui::TextColored(ImVec4(0.45f, 0.8f, 0.45f, 1.0f),
-                                       "This game supplies an exposure and it is being read.");
+                                       Tr("This game supplies an exposure and it is being read."));
                 else if (ex.exposure > 1e-6f)
                 {
                     const float trim =
                         std::clamp(config->DlssNrWhitePointTrim.value_or_default(), 0.25f, 4.0f);
                     ImGui::TextColored(ImVec4(0.45f, 0.8f, 0.45f, 1.0f),
-                                       "Game exposure %.4f  ->  white point %.2f%s", ex.exposure,
+                                       Tr("Game exposure %.4f  ->  white point %.2f%s"), ex.exposure,
                                        ex.preExposure / ex.exposure * trim,
-                                       ex.offeredNow ? "" : "  (held: absent this frame)");
+                                       ex.offeredNow ? "" : Tr("  (held: absent this frame)"));
                 }
                 else
-                    ImGui::TextDisabled("Reading the exposure...");
+                    ImGui::TextDisabled(Tr("Reading the exposure..."));
             }
             else if (source == 2)
             {
@@ -493,23 +806,23 @@ void RenderMenu(Config* config, float menuResScale)
 
                     if (watching == 0)
                         ImGui::TextColored(ImVec4(0.9f, 0.6f, 0.25f, 1.0f),
-                                           "Nothing in this game is shaped like an exposure.");
+                                           Tr("Nothing in this game is shaped like an exposure."));
                     else
                         ImGui::TextColored(ImVec4(0.9f, 0.6f, 0.25f, 1.0f),
-                                           "Watching %u, none moving yet -- go between light and shade.",
+                                           Tr("Watching %u, none moving yet -- go between light and shade."),
                                            watching);
                 }
                 else if (!haveAnchor)
                     ImGui::TextColored(ImVec4(0.9f, 0.6f, 0.25f, 1.0f),
-                                       "Found one. Set paper white below until the picture looks "
-                                       "right, then press Anchor here.");
+                                       Tr("Found one. Set paper white below until the picture looks "
+                                          "right, then press Anchor here."));
                 // Once anchored, the scan -> white point readout sits above the sliders below; it is
                 // not repeated up here.
             }
             else if (haveExposure)
             {
                 ImGui::TextColored(ImVec4(0.45f, 0.8f, 0.45f, 1.0f),
-                                   "This game supplies an exposure -- the option above would use it.");
+                                   Tr("This game supplies an exposure -- the option above would use it."));
             }
         }
 
@@ -582,8 +895,8 @@ void RenderMenu(Config* config, float menuResScale)
                         config->DlssNrScanTrim.value_or_default());
 
                     ImGui::TextColored(ImVec4(0.45f, 0.8f, 0.45f, 1.0f),
-                                       "Scan %.5f  ->  white point %.2f   (%u point%s)", liveScan, w,
-                                       (unsigned) anchors.size(), anchors.size() == 1 ? "" : "s");
+                                       Tr("Scan %.5f  ->  white point %.2f   (%u calibration points)"),
+                                       liveScan, w, (unsigned) anchors.size());
                 }
             }
 
@@ -598,11 +911,11 @@ void RenderMenu(Config* config, float menuResScale)
                 float pw = editingRow ? anchors[selectedAnchor].white
                                       : config->DlssNrWhitePointScale.value_or_default();
 
-                char lbl[48];
+                char lbl[256];
                 if (editingRow)
-                    snprintf(lbl, sizeof(lbl), "Paper white (editing point %d)", selectedAnchor + 1);
+                    snprintf(lbl, sizeof(lbl), Tr("Paper white (editing point %d)"), selectedAnchor + 1);
                 else
-                    snprintf(lbl, sizeof(lbl), "Paper white");
+                    snprintf(lbl, sizeof(lbl), "%s", Tr("Paper white"));
 
                 if (ImGui::SliderFloat(lbl, &pw, 0.25f, 2000.0f, "%.2fx", ImGuiSliderFlags_Logarithmic))
                 {
@@ -630,13 +943,13 @@ void RenderMenu(Config* config, float menuResScale)
             {
                 float trim = config->DlssNrScanTrim.value_or_default();
 
-                if (ImGui::SliderFloat("Trim (x the scan)", &trim, 0.25f, 4.0f, "%.2fx",
+                if (ImGui::SliderFloat(Tr("Trim (x the scan)"), &trim, 0.25f, 4.0f, "%.2fx",
                                        ImGuiSliderFlags_Logarithmic))
                     config->DlssNrScanTrim = std::clamp(trim, 0.25f, 4.0f);
 
                 ImGui::SameLine();
 
-                if (ImGui::SmallButton("Reset##scantrim"))
+                if (ImGui::SmallButton(Tr("Reset##scantrim")))
                     config->DlssNrScanTrim = 1.0f;
 
                 HelpMarker("A multiplier on the scan's white point, and the control you adjust between"
@@ -652,7 +965,7 @@ void RenderMenu(Config* config, float menuResScale)
             float trim = ofScan ? config->DlssNrScanTrim.value_or_default()
                                 : config->DlssNrWhitePointTrim.value_or_default();
 
-            if (ImGui::SliderFloat(ofScan ? "Trim (x the scan)" : "Trim (x the game's exposure)", &trim,
+            if (ImGui::SliderFloat(ofScan ? Tr("Trim (x the scan)") : Tr("Trim (x the game's exposure)"), &trim,
                                    0.25f, 4.0f, "%.2fx", ImGuiSliderFlags_Logarithmic))
             {
                 if (ofScan)
@@ -665,7 +978,7 @@ void RenderMenu(Config* config, float menuResScale)
 
             // Deliberately always present rather than greyed at 1. The point of it is that the safe
             // value is one click away without having to know what the safe value is.
-            if (ImGui::SmallButton("Reset##wptrim"))
+            if (ImGui::SmallButton(Tr("Reset##wptrim")))
             {
                 if (ofScan)
                     config->DlssNrScanTrim = 1.0f;
@@ -692,7 +1005,7 @@ void RenderMenu(Config* config, float menuResScale)
             // of anything that can be bounded here. One tester was still improving at 100.
             float wpScale = config->DlssNrWhitePointScale.value_or_default();
 
-            if (ImGui::SliderFloat("Paper white", &wpScale, 0.25f, 2000.0f, "%.2fx",
+            if (ImGui::SliderFloat(Tr("Paper white"), &wpScale, 0.25f, 2000.0f, "%.2fx",
                                    ImGuiSliderFlags_Logarithmic))
                 config->DlssNrWhitePointScale = wpScale;
 
@@ -721,11 +1034,11 @@ void RenderMenu(Config* config, float menuResScale)
         // Highlight guard, directly under the white point / trim -- it bounds the model's edit and
         // belongs with the exposure controls it works alongside.
         float maxRatio = config->DlssNrMaxRatio.value_or_default();
-        if (ImGui::SliderFloat("Highlight guard", &maxRatio, 1.0f, 8.0f, "%.1fx"))
+        if (ImGui::SliderFloat(Tr("Highlight guard"), &maxRatio, 1.0f, 8.0f, "%.1fx"))
             config->DlssNrMaxRatio = maxRatio;
 
         ImGui::SameLine();
-        if (ImGui::SmallButton("Reset##guard"))
+        if (ImGui::SmallButton(Tr("Reset##guard")))
             config->DlssNrMaxRatio = 2.0f;
 
         HelpMarker("The most the pass may move any pixel, as a multiple of what it already was, in"
@@ -764,7 +1077,7 @@ void RenderMenu(Config* config, float menuResScale)
                 bool meter = config->DlssNrScanMeter.value_or_default();
 
                 if (config->DlssNrWhitePointSource.value_or_default() == 2 &&
-                    ImGui::Checkbox("Show the light meter on screen", &meter))
+                    ImGui::Checkbox(Tr("Show the light meter on screen"), &meter))
                     config->DlssNrScanMeter = meter;
 
                 HelpMarker("A lamp in the corner: red for dark, green for full light, and the"
@@ -798,7 +1111,7 @@ void RenderMenu(Config* config, float menuResScale)
                 // chosen source and it currently has a value to capture.
                 ImGui::BeginDisabled(live <= 0.0f || !isSource);
 
-                if (ImGui::Button("Anchor here"))
+                if (ImGui::Button(Tr("Anchor here")))
                 {
                     // What to capture. Before the first point, the paper white above (an absolute value
                     // with the wide range a fresh game needs). After that, the EFFECTIVE white point the
@@ -837,8 +1150,8 @@ void RenderMenu(Config* config, float menuResScale)
                                "\nand the numbers are the same for everyone who takes the profile.");
 
                 if (!isSource)
-                    ImGui::TextDisabled("(the scan is only watching -- the white point above comes "
-                                        "from somewhere else)");
+                    ImGui::TextDisabled(Tr("(the scan is only watching -- the white point above comes "
+                                          "from somewhere else)"));
 
                 if (!anchors.empty())
                 {
@@ -864,7 +1177,7 @@ void RenderMenu(Config* config, float menuResScale)
                         ImGui::PushID((int) i);
 
                         // Delete first, so its click is never swallowed by the row-wide Selectable.
-                        if (ImGui::SmallButton("x"))
+                        if (ImGui::SmallButton(Tr("x")))
                         {
                             DlssNr::ExposureScan::AnchorRemove((int) i);
                             config->DlssNrScanAnchors = DlssNr::ExposureScan::SerializeAnchors();
@@ -879,10 +1192,10 @@ void RenderMenu(Config* config, float menuResScale)
                         ImGui::SameLine();
 
                         const bool sel = (int) i == selectedAnchor;
-                        char row[96];
-                        snprintf(row, sizeof(row), "%s scan %.4f  ->  white %.2f%s",
+                        char row[256];
+                        snprintf(row, sizeof(row), Tr("%s scan %.4f  ->  white %.2f%s"),
                                  ((int) i == active && isSource) ? ">" : "  ", anchors[i].scan,
-                                 anchors[i].white, sel ? "   [editing]" : "");
+                                 anchors[i].white, sel ? Tr("   [editing]") : "");
 
                         // Click selects the row (slider edits it); click again deselects (slider
                         // returns to the live unanchored point).
@@ -892,8 +1205,8 @@ void RenderMenu(Config* config, float menuResScale)
                         ImGui::PopID();
                     }
 
-                    ImGui::TextDisabled("Click a row to edit it with the slider above; click it again"
-                                        " to control the live point. > is the point in use now.");
+                    ImGui::TextDisabled(Tr("Click a row to edit it with the slider above; click it again"
+                                          " to control the live point. > is the point in use now."));
                 }
 
                 // The direction flag only means anything with a single point; with two or more the
@@ -901,7 +1214,7 @@ void RenderMenu(Config* config, float menuResScale)
                 if (anchors.size() == 1)
                 {
                     bool inverted = config->DlssNrScanInverted.value_or_default();
-                    if (ImGui::Checkbox("The number runs the other way", &inverted))
+                    if (ImGui::Checkbox(Tr("The number runs the other way"), &inverted))
                         config->DlssNrScanInverted = inverted;
 
                     HelpMarker("Flip this if the picture gets worse in the direction it should be"
@@ -916,7 +1229,7 @@ void RenderMenu(Config* config, float menuResScale)
                 // Everything below is read-out rather than control: what the scan is looking at and
                 // how to tell whether it found the right thing. Folded away because the two decisions
                 // that matter -- anchor, and which way the number runs -- are above it.
-                if (ImGui::TreeNode("Advanced"))
+                if (ImGui::TreeNode(Tr("Advanced")))
                 {
 
                     const auto found = DlssNr::ExposureScan::Report();
@@ -925,8 +1238,8 @@ void RenderMenu(Config* config, float menuResScale)
                     if (found.empty())
                     {
                         ImGui::TextDisabled("%s", why != nullptr && why[0] != 0
-                                                      ? why
-                                                      : "nothing matched yet.");
+                                                      ? Tr(why)
+                                                      : Tr("nothing matched yet."));
                     }
                     else
                     {
@@ -936,20 +1249,20 @@ void RenderMenu(Config* config, float menuResScale)
 
                             if (c.reads == 0)
                             {
-                                ImGui::TextDisabled("%zu. %s -- not read yet", i + 1, c.shape.c_str());
+                                ImGui::TextDisabled(Tr("%zu. %s -- not read yet"), i + 1, c.shape.c_str());
                                 continue;
                             }
 
                             // Moving is the whole signal, so it is the thing that is coloured.
                             ImGui::TextColored(c.moves ? ImVec4(0.45f, 0.8f, 0.45f, 1.0f)
                                                        : ImVec4(0.6f, 0.6f, 0.6f, 1.0f),
-                                               "%zu. %s = %.5f  (seen %.5f..%.5f) %s", i + 1,
+                                               Tr("%zu. %s = %.5f  (seen %.5f..%.5f) %s"), i + 1,
                                                c.shape.c_str(), c.latest, c.lowest, c.highest,
-                                               c.moves ? "MOVES" : "flat so far");
+                                               c.moves ? Tr("MOVES") : Tr("flat so far"));
                         }
 
-                        ImGui::TextDisabled("Walk from shade into daylight. A real exposure moves.");
-                        ImGui::TextDisabled("One that only ever climbs is a counter, not an exposure.");
+                        ImGui::TextDisabled(Tr("Walk from shade into daylight. A real exposure moves."));
+                        ImGui::TextDisabled(Tr("One that only ever climbs is a counter, not an exposure."));
                     }
 
                     ImGui::TreePop();
@@ -960,13 +1273,13 @@ void RenderMenu(Config* config, float menuResScale)
 
         }
 
-        ImGui::SeparatorText("Compare");
+        ImGui::SeparatorText(Tr("Compare"));
 
         // Freeze the frame the model works on, so a setting change re-renders it in place -- the only
         // clean way to A/B our own settings (a moving scene confounds every other comparison). See
         // design/frame-hold.md.
         bool held = config->DlssNrHoldFrame.value_or_default();
-        if (ImGui::Checkbox("Hold frame", &held))
+        if (ImGui::Checkbox(Tr("Hold frame"), &held))
             config->DlssNrHoldFrame = held;
 
         HelpMarker("Freezes the frame the model works on. While held, change paper white, the"
@@ -979,9 +1292,9 @@ void RenderMenu(Config* config, float menuResScale)
                        "\ndrift and confound the comparison."
                        "\n\nHide the menu and it stays held. Untoggle to resume.");
 
-        static const char* compareNames[] = { "Off", "Side by side", "Wipe" };
+        static const char* compareNames[] = { Tr("Off"), Tr("Side by side"), Tr("Wipe") };
         int compare = (int) config->DlssNrCompare.value_or_default();
-        if (ImGui::Combo("Compare", &compare, compareNames, IM_ARRAYSIZE(compareNames)))
+        if (ImGui::Combo(Tr("Compare"), &compare, compareNames, IM_ARRAYSIZE(compareNames)))
             config->DlssNrCompare = (uint32_t) compare;
 
         HelpMarker("Shows the pass against itself, so the two can be seen at once rather than"
@@ -997,11 +1310,11 @@ void RenderMenu(Config* config, float menuResScale)
         if (compare != 0)
         {
             bool swap = config->DlssNrCompareSwap.value_or_default();
-            if (ImGui::Checkbox("Swap sides", &swap))
+            if (ImGui::Checkbox(Tr("Swap sides"), &swap))
                 config->DlssNrCompareSwap = swap;
 
             bool tags = config->DlssNrCompareTags.value_or_default();
-            if (ImGui::Checkbox("Label the sides", &tags))
+            if (ImGui::Checkbox(Tr("Label the sides"), &tags))
                 config->DlssNrCompareTags = tags;
 
             HelpMarker("Writes which side is which onto the frame itself, so a screenshot still"
@@ -1013,7 +1326,7 @@ void RenderMenu(Config* config, float menuResScale)
             if (tags)
             {
                 float tagScale = config->DlssNrTagScale.value_or_default();
-                if (ImGui::SliderFloat("Label size", &tagScale, 0.5f, 5.0f, "%.1fx"))
+                if (ImGui::SliderFloat(Tr("Label size"), &tagScale, 0.5f, 5.0f, "%.1fx"))
                     config->DlssNrTagScale = std::clamp(tagScale, 0.5f, 5.0f);
             }
 
@@ -1027,7 +1340,7 @@ void RenderMenu(Config* config, float menuResScale)
         if (compare == 1)
         {
             float zoom = config->DlssNrCompareZoom.value_or_default();
-            if (ImGui::SliderFloat("Zoom", &zoom, 1.0f, 2.0f, "%.2f"))
+            if (ImGui::SliderFloat(Tr("Zoom"), &zoom, 1.0f, 2.0f, "%.2f"))
                 config->DlssNrCompareZoom = std::clamp(zoom, 1.0f, 2.0f);
 
             HelpMarker("How much of the frame each half shows."
@@ -1041,17 +1354,17 @@ void RenderMenu(Config* config, float menuResScale)
         if (compare == 2)
         {
             float split = config->DlssNrCompareSplit.value_or_default();
-            if (ImGui::SliderFloat("Split", &split, 0.0f, 1.0f, "%.2f"))
+            if (ImGui::SliderFloat(Tr("Split"), &split, 0.0f, 1.0f, "%.2f"))
                 config->DlssNrCompareSplit = std::clamp(split, 0.0f, 1.0f);
 
             HelpMarker("Where the wipe cuts. Left of it is the frame as the upscaler produced it,"
                            "\nright of it is the frame the model edited.");
         }
 
-        static const char* debugNames[] = { "Off", "Proxy (what the model sees)", "Model output (raw)",
-                                            "Difference (amplified)" };
+        static const char* debugNames[] = { Tr("Off"), Tr("Proxy (what the model sees)"), Tr("Model output (raw)"),
+                                            Tr("Difference (amplified)") };
         int debugView = (int) config->DlssNrDebugView.value_or_default();
-        if (ImGui::Combo("Debug view", &debugView, debugNames, IM_ARRAYSIZE(debugNames)))
+        if (ImGui::Combo(Tr("Debug view"), &debugView, debugNames, IM_ARRAYSIZE(debugNames)))
             config->DlssNrDebugView = (uint32_t) debugView;
 
         HelpMarker("Proxy is the picture handed to the model -- if that looks wrong, the white point"

--- a/OptiScaler/menu/menu_common.cpp
+++ b/OptiScaler/menu/menu_common.cpp
@@ -38,6 +38,7 @@
 #include <memory>
 #include <type_traits>
 #include <misc/IdentifyGpu.h>
+#include <misc/Localization.h>
 #include <hooks/Xell_Hooks.h>
 #include <low_latency/input/input_common.h>
 
@@ -294,7 +295,7 @@ void MenuCommon::ShowTooltip(const char* tip)
     if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
     {
         ImGui::BeginTooltip();
-        ImGui::Text(tip);
+        ImGui::Text(Tr(tip));
         ImGui::EndTooltip();
     }
 }
@@ -312,7 +313,7 @@ void MenuCommon::ShowResetButton(CustomOptional<bool, NoDefault>* initFlag, std:
 
     ImGui::BeginDisabled(!initFlag->has_value());
 
-    if (ImGui::Button(buttonName.c_str()))
+    if (ImGui::Button(Tr(buttonName.c_str())))
     {
         initFlag->reset();
         ReInitUpscaler();
@@ -337,6 +338,7 @@ inline void MenuCommon::ReInitUpscaler()
 void MenuCommon::SeparatorWithHelpMarker(const char* label, const char* tip)
 {
     auto marker = "(?) ";
+    label = Tr(label);
     ImGui::SeparatorTextEx(0, label, ImGui::FindRenderedTextEnd(label),
                            ImGui::CalcTextSize(marker, ImGui::FindRenderedTextEnd(marker)).x);
     ShowHelpMarker(tip);
@@ -354,7 +356,7 @@ class Keybind
     static std::string KeyNameFromVirtualKeyCode(USHORT virtualKey)
     {
         if (virtualKey == (USHORT) UnboundKey)
-            return "Unbound";
+            return Tr("Unbound");
 
         UINT scanCode = MapVirtualKeyW(virtualKey, MAPVK_VK_TO_VSC);
 
@@ -387,13 +389,13 @@ class Keybind
         if (GetKeyNameTextW(lParam, buf, static_cast<int>(std::size(buf))) != 0)
             return wstring_to_string(buf);
 
-        return "Unknown";
+        return Tr("Unknown");
     }
 
     void Render(CustomOptional<int>& configKey)
     {
         ImGui::PushID(id);
-        if (ImGui::Button(name.c_str()))
+        if (ImGui::Button(Tr(name.c_str())))
         {
             waitingForKey = true;
             capturingKey = true;
@@ -404,7 +406,7 @@ class Keybind
         if (waitingForKey)
         {
             ImGui::SameLine();
-            ImGui::Text("Press any key...");
+            ImGui::TextUnformatted(Tr("Press any key..."));
 
             if (lastKey == 0 || lastKey == VK_LBUTTON || lastKey == VK_RBUTTON || lastKey == VK_MBUTTON)
                 return;
@@ -426,7 +428,7 @@ class Keybind
         }
 
         ImGui::SameLine();
-        ImGui::Text(KeyNameFromVirtualKeyCode(configKey.value_or_default()).c_str());
+        ImGui::TextUnformatted(KeyNameFromVirtualKeyCode(configKey.value_or_default()).c_str());
 
         ImGui::SameLine();
         ImGui::PushID(id);
@@ -561,7 +563,7 @@ template <HasDefaultValue B> void MenuCommon::AddResourceBarrier(std::string nam
         }
     }
 
-    if (ImGui::BeginCombo(name.c_str(), selectedName))
+    if (ImGui::BeginCombo(Tr(name.c_str()), selectedName))
     {
         if (ImGui::Selectable(states[0], !value->has_value()))
             value->reset();
@@ -810,7 +812,7 @@ void MenuCommon::PopulateCombo(const std::string& name, TStorage& currentValue,
         }
     }
 
-    if (ImGui::BeginCombo(name.c_str(), preview.c_str()))
+    if (ImGui::BeginCombo(Tr(name.c_str()), Tr(preview.c_str())))
     {
         for (const auto& opt : options)
         {
@@ -821,12 +823,12 @@ void MenuCommon::PopulateCombo(const std::string& name, TStorage& currentValue,
                 ImGui::BeginDisabled();
 
             bool isSelected = (currentVal == opt.value);
-            if (ImGui::Selectable(opt.label.c_str(), isSelected))
+            if (ImGui::Selectable(Tr(opt.label.c_str()), isSelected))
                 currentValue = opt.value;
 
             // Show tooltip for the individual item if it exists
             if (!opt.tooltip.empty() && ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-                ImGui::SetTooltip("%s", opt.tooltip.c_str());
+                ImGui::SetTooltip("%s", Tr(opt.tooltip.c_str()));
 
             if (opt.disabled)
                 ImGui::EndDisabled();
@@ -1681,8 +1683,8 @@ void MenuCommon::RenderNrCompareTags()
 
     // The left side is the untouched frame unless swapped -- matching the shader's
     // showOriginal = (uv.x < split) != swap.
-    const char* leftText = swap ? "DLSS NR : ON" : "DLSS NR : OFF";
-    const char* rightText = swap ? "DLSS NR : OFF" : "DLSS NR : ON";
+    const char* leftText = Tr(swap ? "DLSS NR : ON" : "DLSS NR : OFF");
+    const char* rightText = Tr(swap ? "DLSS NR : OFF" : "DLSS NR : ON");
 
     ImDrawList* dl = ImGui::GetForegroundDrawList();
     ImFont* font = ImGui::GetFont();
@@ -2245,13 +2247,13 @@ void MenuCommon::RenderMainMenuHeaderMessages(RenderMenuContext& ctx)
         if (versionStatus.updateAvailable && !versionStatus.latestTag.empty())
         {
             ImGui::Spacing();
-            ImGui::TextColored(toneMapColor(ImVec4(1.f, 0.8f, 0.f, 1.f)), "Update available: %s (current %s)",
+            ImGui::TextColored(toneMapColor(ImVec4(1.f, 0.8f, 0.f, 1.f)), Tr("Update available: %s (current %s)"),
                                versionStatus.latestTag.c_str(), currentVersionText.c_str());
 
             if (!versionStatus.latestUrl.empty())
             {
                 ImGui::SameLine();
-                ImGui::TextLinkOpenURL("Open release page", versionStatus.latestUrl.c_str());
+                ImGui::TextLinkOpenURL(Tr("Open release page"), versionStatus.latestUrl.c_str());
             }
 
             ImGui::Spacing();
@@ -2300,8 +2302,8 @@ void MenuCommon::RenderMainMenuHeaderMessages(RenderMenuContext& ctx)
 
             std::string joinedUpscalers(joined.begin(), joined.end());
 
-            ImGui::Text("Please select %s as upscaler from game\noptions and load a save game "
-                        "to enable Opti settings.\nUpscalers don't always work in menus.",
+            ImGui::Text(Tr("Please select %s as upscaler from game\noptions and load a save game "
+                           "to enable Opti settings.\nUpscalers don't always work in menus."),
                         joinedUpscalers.c_str());
 
             if (config->UseHQFont.value_or_default())
@@ -2340,7 +2342,7 @@ void MenuCommon::RenderMainMenuHeaderMessages(RenderMenuContext& ctx)
         else
         {
             ImGui::Spacing();
-            ImGui::Text("Can't find nvngx.dll and libxess.dll and FSR inputs\nUpscaling support will NOT work.");
+            ImGui::TextUnformatted(Tr("Can't find nvngx.dll and libxess.dll and FSR inputs\nUpscaling support will NOT work."));
             ImGui::Spacing();
 
             if (config->UseHQFont.value_or_default())
@@ -2358,7 +2360,7 @@ void MenuCommon::RenderMainMenuHeaderMessages(RenderMenuContext& ctx)
         else
             ImGui::SetWindowFontScale(menuResScale * 3.0f);
 
-        ImGui::Text("%s is active, but not currently used by the game\nPlease enter the game",
+        ImGui::Text(Tr("%s is active, but not currently used by the game\nPlease enter the game"),
                     currentFeature->Name().c_str());
 
         if (config->UseHQFont.value_or_default())
@@ -2379,7 +2381,7 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
     if (currentFeature != nullptr && !currentFeature->IsFrozen())
     {
         // UPSCALERS -----------------------------
-        ImGui::SeparatorText("Upscalers");
+        ImGui::SeparatorText(Tr("Upscalers"));
         ShowTooltip("Which copium do you choose?");
 
         GetCurrentBackendInfo(state.api, currentBackend, &currentBackendName);
@@ -2505,7 +2507,7 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
         if (state.api == DX11 && currentFeature->IsWithDx12())
         {
             ImGui::Spacing();
-            if (auto ch = ScopedCollapsingHeader("Dx11 with Dx12 Settings"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Dx11 with Dx12 Settings")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -2522,7 +2524,7 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
         if (state.api == Vulkan && currentFeature->IsWithDx12())
         {
             ImGui::Spacing();
-            if (auto ch = ScopedCollapsingHeader("Vulkan with Dx12 Settings"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Vulkan with Dx12 Settings")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -2546,7 +2548,7 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
         if (currentBackend == Upscaler::XeSS && !usesDlssd)
         {
             ImGui::Spacing();
-            if (auto ch = ScopedCollapsingHeader("XeSS Settings"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("XeSS Settings")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -2602,7 +2604,7 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
         // FFX -----------------
         if (!usesDlssd && (currentBackend == Upscaler::FFX || currentBackend == Upscaler::FFX_on12))
         {
-            ImGui::SeparatorText("FFX Settings");
+            ImGui::SeparatorText(Tr("FFX Settings"));
 
             if (_ffxUpscalerIndex < 0)
                 _ffxUpscalerIndex = config->FfxUpscalerIndex.value_or_default();
@@ -2836,7 +2838,7 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
 
                     ImGui::Spacing();
 
-                    if (auto ch = ScopedCollapsingHeader("FSR 3 Upscaler Manual Tuning"); ch.IsHeaderOpen())
+                    if (auto ch = ScopedCollapsingHeader(Tr("FSR 3 Upscaler Manual Tuning")); ch.IsHeaderOpen())
                     {
                         ScopedIndent indent {};
                         ImGui::Spacing();
@@ -2908,9 +2910,9 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
         {
 
             if (usesDlssd)
-                ImGui::SeparatorText("DLSSD Settings");
+                ImGui::SeparatorText(Tr("DLSSD Settings"));
             else
-                ImGui::SeparatorText("DLSS Settings");
+                ImGui::SeparatorText(Tr("DLSS Settings"));
 
             auto overridden =
                 usesDlssd ? state.dlssdPresetsOverriddenExternally : state.dlssPresetsOverriddenExternally;
@@ -3005,7 +3007,7 @@ void MenuCommon::RenderActiveUpscalerSettings(RenderMenuContext& ctx)
 
             ImGui::Spacing();
 
-            if (auto ch = ScopedCollapsingHeader(usesDlssd ? "Advanced DLSSD Settings" : "Advanced DLSS Settings");
+            if (auto ch = ScopedCollapsingHeader(Tr(usesDlssd ? "Advanced DLSSD Settings" : "Advanced DLSS Settings"));
                 ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
@@ -3258,7 +3260,7 @@ void MenuCommon::RenderFrameGenerationSelection(RenderMenuContext& ctx)
 
     if (state.activeFgInput != FGInput::ForceXeLL)
     {
-        ImGui::SeparatorText("Frame Generation");
+        ImGui::SeparatorText(Tr("Frame Generation"));
 
         if (ImGui::BeginTable("fgSelection", 2, ImGuiTableFlags_SizingStretchSame))
         {
@@ -3457,7 +3459,7 @@ void MenuCommon::RenderFrameGenerationSelection(RenderMenuContext& ctx)
         {
             ImGui::Spacing();
 
-            if (auto ch = ScopedCollapsingHeader("Advanced FG Settings"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Advanced FG Settings")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -3619,7 +3621,7 @@ void MenuCommon::RenderFrameGenerationRuntimeSettings(RenderMenuContext& ctx)
         if (state.activeFgInput != FGInput::Upscaler ||
             (currentFeature != nullptr && !currentFeature->IsFrozen()) && FfxApiProxy::IsFGReady())
         {
-            ImGui::SeparatorText("Frame Generation (FSR FG)");
+            ImGui::SeparatorText(Tr("Frame Generation (FSR FG)"));
 
             if (_ffxFGIndex < 0)
                 _ffxFGIndex = config->FfxFGIndex.value_or_default();
@@ -3718,7 +3720,7 @@ void MenuCommon::RenderFrameGenerationRuntimeSettings(RenderMenuContext& ctx)
 
             ImGui::Spacing();
 
-            if (auto ch = ScopedCollapsingHeader("Extended FSR FG Settings"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Extended FSR FG Settings")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -3869,7 +3871,7 @@ void MenuCommon::RenderFrameGenerationRuntimeSettings(RenderMenuContext& ctx)
         state.activeFgInput != FGInput::ForceXeLL && state.currentFGSwapchain != nullptr && XeFGProxy::InitXeFG() &&
         fgOutput)
     {
-        ImGui::SeparatorText("Frame Generation (XeFG)");
+        ImGui::SeparatorText(Tr("Frame Generation (XeFG)"));
 
         bool ignoreChecks = config->FGXeFGIgnoreInitChecks.value_or_default();
 
@@ -4018,7 +4020,7 @@ void MenuCommon::RenderFrameGenerationRuntimeSettings(RenderMenuContext& ctx)
         // ShowHelpMarker("Display only XeFG generated frames");
 
         ImGui::Spacing();
-        if (auto ch = ScopedCollapsingHeader("Extended XeFG Settings"); ch.IsHeaderOpen())
+        if (auto ch = ScopedCollapsingHeader(Tr("Extended XeFG Settings")); ch.IsHeaderOpen())
         {
             ImGui::Spacing();
             if (ImGui::TreeNode("Rectangle Settings"))
@@ -4071,7 +4073,7 @@ void MenuCommon::RenderFrameGenerationRuntimeSettings(RenderMenuContext& ctx)
     if (state.activeFgOutput == FGOutput::DLSSG && state.activeFgInput != FGInput::NoFG &&
         state.currentFGSwapchain != nullptr && StreamlineProxy::LoadStreamline() && fgOutput)
     {
-        ImGui::SeparatorText("Frame Generation (DLSSG)");
+        ImGui::SeparatorText(Tr("Frame Generation (DLSSG)"));
 
         if (state.activeFgNvngx == FGNvngxReplacement::None && state.isHdrActive)
         {
@@ -4274,7 +4276,7 @@ void MenuCommon::RenderFrameGenerationRuntimeSettings(RenderMenuContext& ctx)
 
             ImGui::Spacing();
 
-            if (auto ch = ScopedCollapsingHeader("Advanced OptiFG Settings"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Advanced OptiFG Settings")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
 
@@ -4631,7 +4633,7 @@ void MenuCommon::RenderFrameGenerationRuntimeSettings(RenderMenuContext& ctx)
 
                 ImGui::Spacing();
 
-                if (auto ch = ScopedCollapsingHeader("Active DispatchFlags"); ch.IsHeaderOpen())
+                if (auto ch = ScopedCollapsingHeader(Tr("Active DispatchFlags")); ch.IsHeaderOpen())
                 {
                     ScopedIndent indent {};
 
@@ -4866,7 +4868,7 @@ void MenuCommon::RenderFsrCommonSettings(RenderMenuContext& ctx)
                 config->FsrUseFsrInputValues = useFsrVales;
 
             ImGui::Spacing();
-            if (auto ch = ScopedCollapsingHeader("FoV & Camera Values"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("FoV & Camera Values")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -5038,7 +5040,7 @@ void MenuCommon::RenderFramerateSettings(RenderMenuContext& ctx)
         }
 
         ImGui::Spacing();
-        if (auto ch = ScopedCollapsingHeader("VRR Frame Cap Calculator"); ch.IsHeaderOpen())
+        if (auto ch = ScopedCollapsingHeader(Tr("VRR Frame Cap Calculator")); ch.IsHeaderOpen())
         {
             ScopedIndent indent {};
             ImGui::Spacing();
@@ -5162,7 +5164,7 @@ void MenuCommon::RenderLowLatencySettings(RenderMenuContext& ctx)
     auto config = ctx.config;
 
     // Low Latency ---------------------------
-    ImGui::SeparatorText("Low Latency");
+    ImGui::SeparatorText(Tr("Low Latency"));
 
     static std::vector<MenuOption<LowLatencyInput>> lowLatencyInput = {
         { LowLatencyInput::None, "None (Off)" },    { LowLatencyInput::Auto, "Auto" },
@@ -5264,7 +5266,7 @@ void MenuCommon::RenderActiveImageSettings(RenderMenuContext& ctx)
     if (currentFeature != nullptr && !currentFeature->IsFrozen())
     {
         // SHARPNESS -----------------------------
-        ImGui::SeparatorText("Sharpness");
+        ImGui::SeparatorText(Tr("Sharpness"));
 
         if (bool overrideSharpness = config->OverrideSharpness.value_or_default();
             ImGui::Checkbox("Override", &overrideSharpness))
@@ -5377,7 +5379,7 @@ void MenuCommon::RenderActiveImageSettings(RenderMenuContext& ctx)
                                "More red areas will have more sharpness applied\n"
                                "Green areas will get reduced sharpness");
 
-                if (auto ch = ScopedCollapsingHeader("Advanced DA Parameters"); ch.IsHeaderOpen())
+                if (auto ch = ScopedCollapsingHeader(Tr("Advanced DA Parameters")); ch.IsHeaderOpen())
                 {
                     ScopedIndent indent {};
                     ImGui::Spacing();
@@ -5468,7 +5470,7 @@ void MenuCommon::RenderActiveImageSettings(RenderMenuContext& ctx)
             }
 
             ImGui::Spacing();
-            if (auto ch = ScopedCollapsingHeader("Motion Adaptive Sharpness##2"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Motion Adaptive Sharpness##2")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -5524,7 +5526,7 @@ void MenuCommon::RenderActiveImageSettings(RenderMenuContext& ctx)
         auto minSliderLimit = config->ExtendedLimits.value_or_default() ? 0.1f : 1.0f;
         auto maxSliderLimit = config->ExtendedLimits.value_or_default() ? 6.0f : 3.0f;
 
-        ImGui::SeparatorText("Upscale Ratio Override");
+        ImGui::SeparatorText(Tr("Upscale Ratio Override"));
 
         if (bool upOverride = config->UpscaleRatioOverrideEnabled.value_or_default();
             ImGui::Checkbox("Override all", &upOverride))
@@ -5595,7 +5597,7 @@ void MenuCommon::RenderActiveImageSettings(RenderMenuContext& ctx)
                 ImGui::BeginDisabled(!currentFeature->LowResMV() &&
                                      currentFeature->RenderWidth() != currentFeature->DisplayWidth());
 
-                ImGui::SeparatorText("Output Scaling");
+                ImGui::SeparatorText(Tr("Output Scaling"));
 
                 float defaultRatio = 1.5f;
 
@@ -5708,7 +5710,7 @@ void MenuCommon::RenderActiveImageSettings(RenderMenuContext& ctx)
         }
 
         // INIT -----------------------------
-        ImGui::SeparatorText("Init Flags");
+        ImGui::SeparatorText(Tr("Init Flags"));
         if (ImGui::BeginTable("init", 2, ImGuiTableFlags_SizingStretchProp))
         {
             ImGui::TableNextColumn();
@@ -5762,7 +5764,7 @@ void MenuCommon::RenderActiveImageSettings(RenderMenuContext& ctx)
             ImGui::EndTable();
 
             ImGui::Spacing();
-            if (auto ch = ScopedCollapsingHeader("Advanced Init Flags"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Advanced Init Flags")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -5861,44 +5863,44 @@ void MenuCommon::RenderMagnifierSettings(RenderMenuContext& ctx)
 
     // Magnifier -----------------------------
     ImGui::Spacing();
-    if (auto ch = ScopedCollapsingHeader("Magnifier"); ch.IsHeaderOpen())
+    if (auto ch = ScopedCollapsingHeader(Tr("Magnifier")); ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
         ImGui::Spacing();
 
         bool magnifierEnabled = config->MagnifierEnabled.value_or_default();
-        if (ImGui::Checkbox("Enable Magnifier", &magnifierEnabled))
+        if (ImGui::Checkbox(Tr("Enable Magnifier"), &magnifierEnabled))
             config->MagnifierEnabled = magnifierEnabled;
 
         ImGui::BeginDisabled(!magnifierEnabled);
 
         float magnifierSize = config->MagnifierSize.value_or_default();
-        if (ImGui::SliderFloat("Size", &magnifierSize, 5.0f, 50.0f, "%.1f%% of screen"))
+        if (ImGui::SliderFloat(Tr("Size"), &magnifierSize, 5.0f, 50.0f, Tr("%.1f%% of screen")))
             config->MagnifierSize = magnifierSize;
 
         int zoomFactor = config->MagnifierZoomFactor.value_or_default();
-        if (ImGui::SliderInt("Zoom Factor", &zoomFactor, 2, 20, "%dx"))
+        if (ImGui::SliderInt(Tr("Zoom Factor"), &zoomFactor, 2, 20, "%dx"))
             config->MagnifierZoomFactor = zoomFactor;
 
         float borderSize = config->MagnifierBorderSize.value_or_default();
-        if (ImGui::SliderFloat("Border Size", &borderSize, 0.0f, 2.0f, "%.2f%% of screen"))
+        if (ImGui::SliderFloat(Tr("Border Size"), &borderSize, 0.0f, 2.0f, Tr("%.2f%% of screen")))
             config->MagnifierBorderSize = borderSize;
 
         ImGui::Separator();
-        ImGui::Text("Positioning");
+        ImGui::TextUnformatted(Tr("Positioning"));
 
         bool staticMode = config->MagnifierStaticPosX.has_value() && config->MagnifierStaticPosY.has_value();
         if (staticMode)
         {
             float staticX = config->MagnifierStaticPosX.value();
-            if (ImGui::SliderFloat("Static Pos X", &staticX, 0.0f, 100.0f, "%.1f%%"))
+            if (ImGui::SliderFloat(Tr("Static Pos X"), &staticX, 0.0f, 100.0f, "%.1f%%"))
                 config->MagnifierStaticPosX = staticX;
 
             float staticY = config->MagnifierStaticPosY.value();
-            if (ImGui::SliderFloat("Static Pos Y", &staticY, 0.0f, 100.0f, "%.1f%%"))
+            if (ImGui::SliderFloat(Tr("Static Pos Y"), &staticY, 0.0f, 100.0f, "%.1f%%"))
                 config->MagnifierStaticPosY = staticY;
 
-            if (ImGui::Button("Reset Static Position (Follow Cursor)"))
+            if (ImGui::Button(Tr("Reset Static Position (Follow Cursor)")))
             {
                 config->MagnifierStaticPosX.reset();
                 config->MagnifierStaticPosY.reset();
@@ -5907,20 +5909,20 @@ void MenuCommon::RenderMagnifierSettings(RenderMenuContext& ctx)
         else
         {
             // Button to initialize static position mode
-            if (ImGui::Button("Set Static Position"))
+            if (ImGui::Button(Tr("Set Static Position")))
             {
                 config->MagnifierStaticPosX = 50.0f;
                 config->MagnifierStaticPosY = 50.0f;
             }
             ImGui::SameLine();
-            ImGui::TextDisabled("(Currently following cursor)");
+            ImGui::TextDisabled("%s", Tr("(Currently following cursor)"));
 
             float offsetX = config->MagnifierCursorOffsetX.value_or_default();
-            if (ImGui::SliderFloat("Cursor Offset X", &offsetX, -300.0f, 300.0f, "%.0f px"))
+            if (ImGui::SliderFloat(Tr("Cursor Offset X"), &offsetX, -300.0f, 300.0f, "%.0f px"))
                 config->MagnifierCursorOffsetX = offsetX;
 
             float offsetY = config->MagnifierCursorOffsetY.value_or_default();
-            if (ImGui::SliderFloat("Cursor Offset Y", &offsetY, -300.0f, 300.0f, "%.0f px"))
+            if (ImGui::SliderFloat(Tr("Cursor Offset Y"), &offsetY, -300.0f, 300.0f, "%.0f px"))
                 config->MagnifierCursorOffsetY = offsetY;
         }
 
@@ -5936,7 +5938,7 @@ void MenuCommon::RenderQuirksSettings(RenderMenuContext& ctx)
     if (state.detectedQuirks.size() > 0)
     {
         ImGui::Spacing();
-        if (auto ch = ScopedCollapsingHeader("Active Quirks"); ch.IsHeaderOpen())
+        if (auto ch = ScopedCollapsingHeader(Tr("Active Quirks")); ch.IsHeaderOpen())
         {
             ScopedIndent indent {};
             ImGui::Spacing();
@@ -5957,7 +5959,7 @@ void MenuCommon::RenderAdvancedSettings(RenderMenuContext& ctx)
 
     // ADVANCED SETTINGS -----------------------------
     ImGui::Spacing();
-    if (auto ch = ScopedCollapsingHeader("Advanced Settings"); ch.IsHeaderOpen())
+    if (auto ch = ScopedCollapsingHeader(Tr("Advanced Settings")); ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
         ImGui::Spacing();
@@ -5965,7 +5967,7 @@ void MenuCommon::RenderAdvancedSettings(RenderMenuContext& ctx)
         if (currentFeature != nullptr && !currentFeature->IsFrozen())
         {
             bool extendedLimits = config->ExtendedLimits.value_or_default();
-            if (ImGui::Checkbox("Enable Extended Limits", &extendedLimits))
+            if (ImGui::Checkbox(Tr("Enable Extended Limits"), &extendedLimits))
                 config->ExtendedLimits = extendedLimits;
 
             ShowHelpMarker("Extended sliders limit for quality presets\n\n"
@@ -5974,7 +5976,7 @@ void MenuCommon::RenderAdvancedSettings(RenderMenuContext& ctx)
         }
 
         bool pcShaders = config->UsePrecompiledShaders.value_or_default();
-        if (ImGui::Checkbox("Use Precompiled Shaders", &pcShaders))
+        if (ImGui::Checkbox(Tr("Use Precompiled Shaders"), &pcShaders))
         {
             config->UsePrecompiledShaders = pcShaders;
             state.newBackend = currentBackend;
@@ -5982,18 +5984,18 @@ void MenuCommon::RenderAdvancedSettings(RenderMenuContext& ctx)
         }
 
         // DRS
-        ImGui::SeparatorText("DRS (Dynamic Resolution Scaling)");
+        ImGui::SeparatorText(Tr("DRS (Dynamic Resolution Scaling)"));
         if (ImGui::BeginTable("drs", 2, ImGuiTableFlags_SizingStretchProp))
         {
             ImGui::TableNextColumn();
             if (bool drsMin = config->DrsMinOverrideEnabled.value_or_default();
-                ImGui::Checkbox("Override Minimum", &drsMin))
+                ImGui::Checkbox(Tr("Override Minimum"), &drsMin))
                 config->DrsMinOverrideEnabled = drsMin;
             ShowHelpMarker("Fix for games ignoring official DRS limits");
 
             ImGui::TableNextColumn();
             if (bool drsMax = config->DrsMaxOverrideEnabled.value_or_default();
-                ImGui::Checkbox("Override Maximum", &drsMax))
+                ImGui::Checkbox(Tr("Override Maximum"), &drsMax))
                 config->DrsMaxOverrideEnabled = drsMax;
             ShowHelpMarker("Fix for games ignoring official DRS limits");
 
@@ -6005,7 +6007,7 @@ void MenuCommon::RenderAdvancedSettings(RenderMenuContext& ctx)
         {
             // BARRIERS -----------------------------
             ImGui::Spacing();
-            if (auto ch = ScopedCollapsingHeader("Resource Barriers"); ch.IsHeaderOpen())
+            if (auto ch = ScopedCollapsingHeader(Tr("Resource Barriers")); ch.IsHeaderOpen())
             {
                 ScopedIndent indent {};
                 ImGui::Spacing();
@@ -6022,17 +6024,17 @@ void MenuCommon::RenderAdvancedSettings(RenderMenuContext& ctx)
             if (state.api == DX12)
             {
                 ImGui::Spacing();
-                if (auto ch = ScopedCollapsingHeader("Root Signatures"); ch.IsHeaderOpen())
+                if (auto ch = ScopedCollapsingHeader(Tr("Root Signatures")); ch.IsHeaderOpen())
                 {
                     ScopedIndent indent {};
                     ImGui::Spacing();
 
                     if (bool crs = config->RestoreComputeSignature.value_or_default();
-                        ImGui::Checkbox("Restore Compute Root Signature", &crs))
+                        ImGui::Checkbox(Tr("Restore Compute Root Signature"), &crs))
                         config->RestoreComputeSignature = crs;
 
                     if (bool grs = config->RestoreGraphicSignature.value_or_default();
-                        ImGui::Checkbox("Restore Graphic Root Signature", &grs))
+                        ImGui::Checkbox(Tr("Restore Graphic Root Signature"), &grs))
                         config->RestoreGraphicSignature = grs;
                 }
             }
@@ -6046,7 +6048,7 @@ void MenuCommon::RenderLoggingSettings(RenderMenuContext& ctx)
 
     // LOGGING -----------------------------
     ImGui::Spacing();
-    if (auto ch = ScopedCollapsingHeader("Logging"); ch.IsHeaderOpen())
+    if (auto ch = ScopedCollapsingHeader(Tr("Logging")); ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
         ImGui::Spacing();
@@ -6057,14 +6059,14 @@ void MenuCommon::RenderLoggingSettings(RenderMenuContext& ctx)
         else
             spdlog::default_logger()->set_level(spdlog::level::off);
 
-        if (bool toFile = config->LogToFile.value_or_default(); ImGui::Checkbox("To File", &toFile))
+        if (bool toFile = config->LogToFile.value_or_default(); ImGui::Checkbox(Tr("To File"), &toFile))
         {
             config->LogToFile = toFile;
             PrepareLogger();
         }
 
         ImGui::SameLine(0.0f, 6.0f);
-        if (bool toConsole = config->LogToConsole.value_or_default(); ImGui::Checkbox("To Console", &toConsole))
+        if (bool toConsole = config->LogToConsole.value_or_default(); ImGui::Checkbox(Tr("To Console"), &toConsole))
         {
             config->LogToConsole = toConsole;
             PrepareLogger();
@@ -6073,11 +6075,11 @@ void MenuCommon::RenderLoggingSettings(RenderMenuContext& ctx)
         const char* logLevels[] = { "Trace", "Debug", "Information", "Warning", "Error" };
         const char* selectedLevel = logLevels[config->LogLevel.value_or_default()];
 
-        if (ImGui::BeginCombo("Log Level", selectedLevel))
+        if (ImGui::BeginCombo(Tr("Log Level"), Tr(selectedLevel)))
         {
             for (int n = 0; n < 5; n++)
             {
-                if (ImGui::Selectable(logLevels[n], (config->LogLevel.value_or_default() == n)))
+                if (ImGui::Selectable(Tr(logLevels[n]), (config->LogLevel.value_or_default() == n)))
                 {
                     config->LogLevel = n;
                     spdlog::default_logger()->set_level(
@@ -6096,7 +6098,7 @@ void MenuCommon::RenderThemeSettings(RenderMenuContext& ctx)
 
     // THEME -----------------------------
     ImGui::Spacing();
-    if (auto ch = ScopedCollapsingHeader("Menu Theme and Color"); ch.IsHeaderOpen())
+    if (auto ch = ScopedCollapsingHeader(Tr("Menu Theme and Color")); ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
         ImGui::Spacing();
@@ -6119,15 +6121,15 @@ void MenuCommon::RenderThemeSettings(RenderMenuContext& ctx)
         auto AccentStrong = [&](ImVec4 accent, float alpha = 1.0f)
         { return toneMapColor(ImVec4(accent.x, accent.y, accent.z, alpha)); };
 
-        if (ImGui::Checkbox("Light Theme", &lightTheme))
+        if (ImGui::Checkbox(Tr("Light Theme"), &lightTheme))
         {
             config->LightTheme = lightTheme;
             ApplyThemeStyle();
         }
 
-        ImGui::SeparatorText("Accent Colour");
+        ImGui::SeparatorText(Tr("Accent Colour"));
 
-        ImGui::Text("Presets:");
+        ImGui::TextUnformatted(Tr("Presets:"));
         ImGui::SameLine(0.0f, 6.0f);
 
         ImVec4 colorBlue = { 0.00f, 0.40f, 0.77f, 1.0f };
@@ -6321,7 +6323,7 @@ void MenuCommon::RenderThemeSettings(RenderMenuContext& ctx)
 
         ImGui::Spacing();
 
-        if (ImGui::Button("Reset Accent Color"))
+        if (ImGui::Button(Tr("Reset Accent Color")))
         {
             config->MenuAccentColorR.reset();
             config->MenuAccentColorG.reset();
@@ -6331,9 +6333,9 @@ void MenuCommon::RenderThemeSettings(RenderMenuContext& ctx)
 
         ImGui::Spacing();
 
-        ImGui::SeparatorText("Background Colour");
+        ImGui::SeparatorText(Tr("Background Colour"));
 
-        ImGui::Text("Presets:");
+        ImGui::TextUnformatted(Tr("Presets:"));
         ImGui::SameLine(0.0f, 6.0f);
 
         color = colorBlue;
@@ -6543,29 +6545,29 @@ void MenuCommon::RenderFpsOverlaySettings(RenderMenuContext& ctx)
 
     // FPS OVERLAY -----------------------------
     ImGui::Spacing();
-    if (auto ch = ScopedCollapsingHeader("FPS Overlay"); ch.IsHeaderOpen())
+    if (auto ch = ScopedCollapsingHeader(Tr("FPS Overlay")); ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
         ImGui::Spacing();
 
         bool fpsEnabled = config->ShowFps.value_or_default();
-        if (ImGui::Checkbox("FPS Overlay Enabled", &fpsEnabled))
+        if (ImGui::Checkbox(Tr("FPS Overlay Enabled"), &fpsEnabled))
             config->ShowFps = fpsEnabled;
 
         ImGui::SameLine(0.0f, 6.0f);
 
         bool fpsHorizontal = config->FpsOverlayHorizontal.value_or_default();
-        if (ImGui::Checkbox("Horizontal", &fpsHorizontal))
+        if (ImGui::Checkbox(Tr("Horizontal"), &fpsHorizontal))
             config->FpsOverlayHorizontal = fpsHorizontal;
 
         const char* fpsPosition[] = { "Top Left", "Top Right", "Bottom Left", "Bottom Right" };
         const char* selectedPosition = fpsPosition[config->FpsOverlayPosition.value_or_default()];
 
-        if (ImGui::BeginCombo("Overlay Position", selectedPosition))
+        if (ImGui::BeginCombo(Tr("Overlay Position"), Tr(selectedPosition)))
         {
             for (int n = 0; n < std::size(fpsPosition); n++)
             {
-                if (ImGui::Selectable(fpsPosition[n], (config->FpsOverlayPosition.value_or_default() == n)))
+                if (ImGui::Selectable(Tr(fpsPosition[n]), (config->FpsOverlayPosition.value_or_default() == n)))
                     config->FpsOverlayPosition = (FpsOverlayPos) n;
             }
 
@@ -6576,11 +6578,11 @@ void MenuCommon::RenderFpsOverlaySettings(RenderMenuContext& ctx)
                                   "Full",     "Full + Graph", "Reflex timings" };
         const char* selectedType = fpsType[config->FpsOverlayType.value_or_default()];
 
-        if (ImGui::BeginCombo("Overlay Type", selectedType))
+        if (ImGui::BeginCombo(Tr("Overlay Type"), Tr(selectedType)))
         {
             for (int n = 0; n < std::size(fpsType); n++)
             {
-                if (ImGui::Selectable(fpsType[n], (config->FpsOverlayType.value_or_default() == n)))
+                if (ImGui::Selectable(Tr(fpsType[n]), (config->FpsOverlayType.value_or_default() == n)))
                     config->FpsOverlayType = (FpsOverlay) n;
             }
 
@@ -6588,7 +6590,7 @@ void MenuCommon::RenderFpsOverlaySettings(RenderMenuContext& ctx)
         }
 
         float fpsAlpha = config->FpsOverlayAlpha.value_or_default();
-        if (ImGui::SliderFloat("Background Alpha", &fpsAlpha, 0.0f, 1.0f, "%.2f"))
+        if (ImGui::SliderFloat(Tr("Background Alpha"), &fpsAlpha, 0.0f, 1.0f, "%.2f"))
             config->FpsOverlayAlpha = fpsAlpha;
 
         const char* options[] = { "Same as menu", "0.5", "0.6", "0.7", "0.8", "0.9", "1.0", "1.1", "1.2",
@@ -6597,7 +6599,7 @@ void MenuCommon::RenderFpsOverlaySettings(RenderMenuContext& ctx)
         float values[] = { 0.0f, 0.5f, 0.6f, 0.7f, 0.8f, 0.9f, 1.0f, 1.1f, 1.2f,
                            1.3f, 1.4f, 1.5f, 1.6f, 1.7f, 1.8f, 1.9f, 2.0f };
 
-        if (ImGui::SliderInt("Scale", &currentIndex, 0, IM_ARRAYSIZE(options) - 1, options[currentIndex],
+        if (ImGui::SliderInt(Tr("Scale"), &currentIndex, 0, IM_ARRAYSIZE(options) - 1, Tr(options[currentIndex]),
                              ImGuiSliderFlags_ClampOnInput))
         {
             if (currentIndex == 0)
@@ -6607,7 +6609,7 @@ void MenuCommon::RenderFpsOverlaySettings(RenderMenuContext& ctx)
         }
 
         bool useTheme = config->OverlaysUseTheme.value_or_default();
-        if (ImGui::Checkbox("Use Theme Colors", &useTheme))
+        if (ImGui::Checkbox(Tr("Use Theme Colors"), &useTheme))
             config->OverlaysUseTheme = useTheme;
     }
 }
@@ -6620,7 +6622,7 @@ void MenuCommon::RenderUpscalerInputsSettings(RenderMenuContext& ctx)
     // UPSCALER INPUTS -----------------------------
     ImGui::Spacing();
     auto uiStateOpen = currentFeature == nullptr || currentFeature->IsFrozen();
-    if (auto ch = ScopedCollapsingHeader("Upscaler Inputs", uiStateOpen ? ImGuiTreeNodeFlags_DefaultOpen : 0);
+    if (auto ch = ScopedCollapsingHeader(Tr("Upscaler Inputs"), uiStateOpen ? ImGuiTreeNodeFlags_DefaultOpen : 0);
         ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
@@ -6631,10 +6633,10 @@ void MenuCommon::RenderUpscalerInputsSettings(RenderMenuContext& ctx)
             bool fsr2Inputs = config->UseFsr2Inputs.value_or_default();
             bool fsr2Pattern = config->Fsr2Pattern.value_or_default();
 
-            if (ImGui::Checkbox("Use Fsr2 Inputs", &fsr2Inputs))
+            if (ImGui::Checkbox(Tr("Use Fsr2 Inputs"), &fsr2Inputs))
                 config->UseFsr2Inputs = fsr2Inputs;
 
-            if (ImGui::Checkbox("Use Fsr2 Pattern Matching", &fsr2Pattern))
+            if (ImGui::Checkbox(Tr("Use Fsr2 Pattern Matching"), &fsr2Pattern))
                 config->Fsr2Pattern = fsr2Pattern;
             ShowTooltip("This setting will become active on next boot!");
         }
@@ -6644,10 +6646,10 @@ void MenuCommon::RenderUpscalerInputsSettings(RenderMenuContext& ctx)
             bool fsr3Inputs = config->UseFsr3Inputs.value_or_default();
             bool fsr3Pattern = config->Fsr3Pattern.value_or_default();
 
-            if (ImGui::Checkbox("Use Fsr3 Inputs", &fsr3Inputs))
+            if (ImGui::Checkbox(Tr("Use Fsr3 Inputs"), &fsr3Inputs))
                 config->UseFsr3Inputs = fsr3Inputs;
 
-            if (ImGui::Checkbox("Use Fsr3 Pattern Matching", &fsr3Pattern))
+            if (ImGui::Checkbox(Tr("Use Fsr3 Pattern Matching"), &fsr3Pattern))
                 config->Fsr3Pattern = fsr3Pattern;
             ShowTooltip("This setting will become active on next boot!");
         }
@@ -6656,7 +6658,7 @@ void MenuCommon::RenderUpscalerInputsSettings(RenderMenuContext& ctx)
         {
             bool ffxInputs = config->UseFfxInputs.value_or_default();
 
-            if (ImGui::Checkbox("Use Ffx Inputs", &ffxInputs))
+            if (ImGui::Checkbox(Tr("Use Ffx Inputs"), &ffxInputs))
                 config->UseFfxInputs = ffxInputs;
         }
     }
@@ -6674,7 +6676,7 @@ void MenuCommon::RenderApiAndTextureSettings(RenderMenuContext& ctx)
     {
         // V-SYNC -----------------------------
         ImGui::Spacing();
-        if (auto ch = ScopedCollapsingHeader("V-Sync Settings"); ch.IsHeaderOpen())
+        if (auto ch = ScopedCollapsingHeader(Tr("V-Sync Settings")); ch.IsHeaderOpen())
         {
             ScopedIndent indent {};
             ImGui::Spacing();
@@ -6777,7 +6779,7 @@ void MenuCommon::RenderApiAndTextureSettings(RenderMenuContext& ctx)
 
         // MIPMAP BIAS & Anisotropy -----------------------------
         ImGui::Spacing();
-        if (auto ch = ScopedCollapsingHeader("Mipmap Bias", (currentFeature == nullptr || currentFeature->IsFrozen())
+        if (auto ch = ScopedCollapsingHeader(Tr("Mipmap Bias"), (currentFeature == nullptr || currentFeature->IsFrozen())
                                                                 ? ImGuiTreeNodeFlags_DefaultOpen
                                                                 : 0);
             ch.IsHeaderOpen())
@@ -6899,7 +6901,7 @@ void MenuCommon::RenderApiAndTextureSettings(RenderMenuContext& ctx)
 
         ImGui::Spacing();
         if (auto ch = ScopedCollapsingHeader(
-                "Anisotropic Filtering",
+                Tr("Anisotropic Filtering"),
                 (currentFeature == nullptr || currentFeature->IsFrozen()) ? ImGuiTreeNodeFlags_DefaultOpen : 0);
             ch.IsHeaderOpen())
         {
@@ -6964,13 +6966,13 @@ void MenuCommon::RenderKeybindSettings(RenderMenuContext& ctx)
     auto config = ctx.config;
 
     ImGui::Spacing();
-    if (auto ch = ScopedCollapsingHeader("Keybinds"); ch.IsHeaderOpen())
+    if (auto ch = ScopedCollapsingHeader(Tr("Keybinds")); ch.IsHeaderOpen())
     {
         ScopedIndent indent {};
         ImGui::Spacing();
 
-        ImGui::Text("Key combinations are currently NOT supported!");
-        ImGui::Text("Escape to cancel, Backspace to unbind");
+        ImGui::TextUnformatted(Tr("Key combinations are currently NOT supported!"));
+        ImGui::TextUnformatted(Tr("Escape to cancel, Backspace to unbind"));
         ImGui::Spacing();
 
         static auto menu = Keybind("Menu", 10);
@@ -7156,7 +7158,7 @@ void MenuCommon::RenderMainMenuBottomBar(RenderMenuContext& ctx)
 
     ImGui::PushItemWidth(100.0f * menuResScale);
 
-    auto autoText = config->MenuScale.has_value() ? "Auto" : StrFmt("Auto (%3.1f)", menuResScale);
+    auto autoText = config->MenuScale.has_value() ? Tr("Auto") : StrFmt(Tr("Auto (%3.1f)"), menuResScale);
     // clang-format off
     const char* uiScales[] = { autoText.c_str(), "0.5", "0.6", "0.7", "0.8", "0.9", "1.0", "1.1",
                                "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "2.0" };
@@ -7164,7 +7166,7 @@ void MenuCommon::RenderMainMenuBottomBar(RenderMenuContext& ctx)
 
     const char* selectedScaleName = uiScales[_selectedScale];
 
-    if (ImGui::BeginCombo("Menu Scale", selectedScaleName))
+    if (ImGui::BeginCombo(Tr("Menu Scale"), selectedScaleName))
     {
         for (int n = 0; n < std::size(uiScales); n++)
         {
@@ -7186,12 +7188,12 @@ void MenuCommon::RenderMainMenuBottomBar(RenderMenuContext& ctx)
 
     ImGui::SameLine(0.0f, 15.0f);
 
-    if (ImGui::Button("Save Settings"))
+    if (ImGui::Button(Tr("Save Settings")))
         config->SaveIni();
 
     ImGui::SameLine(0.0f, 6.0f);
 
-    if (ImGui::Button("Close"))
+    if (ImGui::Button(Tr("Close")))
     {
         _isVisible = false;
         hasGamepad = (io.BackendFlags | ImGuiBackendFlags_HasGamepad) > 0;
@@ -7210,7 +7212,7 @@ void MenuCommon::RenderMainMenuBottomBar(RenderMenuContext& ctx)
 
     ImGui::SameLine();
 
-    auto textSize = ImGui::CalcTextSize("Open Wiki (?)");
+    auto textSize = ImGui::CalcTextSize(Tr("Open Wiki (?)"));
     auto& style = ImGui::GetStyle();
     textSize.x += style.FramePadding.x * 2.0f;
     textSize.x += style.ItemSpacing.x;
@@ -7219,7 +7221,7 @@ void MenuCommon::RenderMainMenuBottomBar(RenderMenuContext& ctx)
     ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - textSize.x);
 
     // Make button text underline
-    if (ImGui::Button("Open Wiki"))
+    if (ImGui::Button(Tr("Open Wiki")))
     {
         auto pIO = &ImGui::GetPlatformIO();
         auto ctx = ImGui::GetCurrentContext();
@@ -7795,6 +7797,9 @@ void MenuCommon::Init(HWND InHwnd, bool isUWP)
         }
     }
 
+    Localization::Init();
+    const bool chinese = Localization::IsChinese();
+
     if (io.Fonts->Fonts.empty() && Config::Instance()->UseHQFont.value_or_default())
     {
         ImFontAtlas* atlas = io.Fonts;
@@ -7802,6 +7807,8 @@ void MenuCommon::Init(HWND InHwnd, bool isUWP)
 
         // This automatically becomes the next default font
         ImFontConfig fontConfig;
+        if (chinese)
+            fontConfig.Flags |= ImFontFlags_NoLoadError;
 
         if (Config::Instance()->FontSize.has_value())
             fontSize = Config::Instance()->FontSize.value();
@@ -7817,6 +7824,46 @@ void MenuCommon::Init(HWND InHwnd, bool isUWP)
             io.FontDefault = atlas->AddFontFromMemoryCompressedBase85TTF(hack_compressed_compressed_data_base85,
                                                                          fontSize, &fontConfig);
         }
+    }
+
+    if (chinese)
+    {
+        ImFontAtlas* atlas = io.Fonts;
+        // Preserve the selected Latin font (including the normal low-quality font). Merge
+        // Chinese into this context's atlas, never cache fonts across Shutdown/CreateContext.
+        if (atlas->Fonts.empty())
+        {
+            if (Config::Instance()->UseHQFont.value_or_default())
+                io.FontDefault = atlas->AddFontFromMemoryCompressedBase85TTF(hack_compressed_compressed_data_base85,
+                                                                            fontSize);
+            else
+                io.FontDefault = atlas->AddFontDefault();
+        }
+
+        wchar_t windowsDirectory[MAX_PATH + 1] = {};
+        const UINT length = GetWindowsDirectoryW(windowsDirectory, static_cast<UINT>(std::size(windowsDirectory)));
+        bool chineseFontLoaded = false;
+        if (length != 0 && length < std::size(windowsDirectory))
+        {
+            const auto fontPath = std::filesystem::path(windowsDirectory) / L"Fonts" / L"msyh.ttc";
+            ImFontConfig chineseConfig;
+            chineseConfig.MergeMode = true;
+            chineseConfig.Flags |= ImFontFlags_NoLoadError;
+            static const ImWchar s_chineseRanges[] = {
+                0x0020, 0x00FF, // Basic Latin + Latin Supplement
+                0x2000, 0x206F, // General Punctuation
+                0x3000, 0x30FF, // CJK Symbols and Punctuation, Hiragana, Katakana
+                0x31F0, 0x31FF, // Katakana Phonetic Extensions
+                0xFF00, 0xFFEF, // Halfwidth and Fullwidth Forms
+                0x4E00, 0x9FAF, // CJK Unified Ideographs
+                0,
+            };
+            const float size = Config::Instance()->UseHQFont.value_or_default() ? fontSize : 13.0f;
+            chineseFontLoaded = atlas->AddFontFromFileTTF(wstring_to_string(fontPath.wstring()).c_str(), size,
+                                                        &chineseConfig, s_chineseRanges) != nullptr;
+        }
+        if (!chineseFontLoaded)
+            LOG_WARN("Chinese UI font msyh.ttc was not available; keeping the configured menu font");
     }
 
     if (!Config::Instance()->OverlayMenu.value_or_default())

--- a/OptiScaler/misc/Localization.cpp
+++ b/OptiScaler/misc/Localization.cpp
@@ -1,0 +1,269 @@
+#include "pch.h"
+#include "Localization.h"
+
+#include <Util.h>
+
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <limits>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+
+namespace
+{
+struct StringHash
+{
+    using is_transparent = void;
+
+    size_t operator()(std::string_view value) const noexcept { return std::hash<std::string_view> {}(value); }
+};
+
+struct Dictionary
+{
+    std::unordered_map<std::string, std::string, StringHash, std::equal_to<>> translations;
+    bool chinese = PRIMARYLANGID(GetUserDefaultUILanguage()) == LANG_CHINESE ||
+                   PRIMARYLANGID(GetThreadUILanguage()) == LANG_CHINESE;
+};
+
+std::string_view Trim(std::string_view text)
+{
+    const auto begin = text.find_first_not_of(" \t\r\n");
+    if (begin == std::string_view::npos)
+        return {};
+    return text.substr(begin, text.find_last_not_of(" \t\r\n") - begin + 1);
+}
+
+std::string Unescape(std::string_view text)
+{
+    std::string result;
+    result.reserve(text.size());
+    for (size_t i = 0; i < text.size(); ++i)
+    {
+        if (text[i] == '\\' && i + 1 < text.size())
+        {
+            switch (text[i + 1])
+            {
+            case 'n': result += '\n'; ++i; continue;
+            case 'r': result += '\r'; ++i; continue;
+            case 't': result += '\t'; ++i; continue;
+            case 's': result += ' '; ++i; continue;
+            case '\\': result += '\\'; ++i; continue;
+            case '=': result += '='; ++i; continue;
+            }
+        }
+        result += text[i];
+    }
+    return result;
+}
+
+bool IsUtf8(std::string_view text)
+{
+    return !text.empty() && text.size() <= static_cast<size_t>((std::numeric_limits<int>::max)()) &&
+           text.find('\0') == std::string_view::npos &&
+           MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.data(), static_cast<int>(text.size()), nullptr, 0) > 0;
+}
+
+bool IsDigit(char value)
+{
+    return value >= '0' && value <= '9';
+}
+
+// Strictly matching the complete directives also preserves star arguments, integer length,
+// wide/narrow strings, and bounded widths/precisions. Positional parameters, %n, and unknown
+// extensions are deliberately rejected rather than interpreted differently by the CRT/ImGui.
+bool NextDirective(std::string_view text, size_t& cursor, std::string_view& directive)
+{
+    const auto begin = text.find('%', cursor);
+    directive = {};
+    if (begin == std::string_view::npos)
+        return true;
+
+    size_t end = begin + 1;
+    if (end < text.size() && text[end] == '%')
+    {
+        cursor = end + 1;
+        directive = text.substr(begin, cursor - begin);
+        return true;
+    }
+
+    while (end < text.size() && std::string_view("-+ #0").find(text[end]) != std::string_view::npos)
+        ++end;
+    if (end < text.size() && text[end] == '*')
+        ++end;
+    else
+        while (end < text.size() && IsDigit(text[end]))
+            ++end;
+    if (end < text.size() && text[end] == '.')
+    {
+        ++end;
+        if (end < text.size() && text[end] == '*')
+            ++end;
+        else
+            while (end < text.size() && IsDigit(text[end]))
+                ++end;
+    }
+
+    if (text.substr(end, 2) == "hh" || text.substr(end, 2) == "ll")
+        end += 2;
+    else if (text.substr(end, 3) == "I32" || text.substr(end, 3) == "I64")
+        end += 3;
+    else if (end < text.size() && std::string_view("hljztLIw").find(text[end]) != std::string_view::npos)
+        ++end;
+
+    if (end >= text.size() || std::string_view("diouxXfFeEgGaAcCsSp").find(text[end]) == std::string_view::npos)
+        return false;
+
+    cursor = end + 1;
+    directive = text.substr(begin, cursor - begin);
+    return true;
+}
+
+bool HasMatchingFormat(std::string_view source, std::string_view translation)
+{
+    size_t sourceCursor = 0;
+    size_t translationCursor = 0;
+    for (;;)
+    {
+        std::string_view sourceDirective;
+        std::string_view translationDirective;
+        if (!NextDirective(source, sourceCursor, sourceDirective) ||
+            !NextDirective(translation, translationCursor, translationDirective) || sourceDirective != translationDirective)
+            return false;
+        if (sourceDirective.empty())
+            return true;
+    }
+}
+
+bool LoadFile(const std::filesystem::path& path, Dictionary& dictionary)
+{
+    std::ifstream file(path, std::ios::binary);
+    if (!file)
+        return false;
+
+    dictionary.chinese = true;
+    bool firstLine = true;
+    bool inTranslations = false;
+    std::string line;
+    while (std::getline(file, line))
+    {
+        std::string_view text(line);
+        if (firstLine && text.starts_with("\xEF\xBB\xBF"))
+            text.remove_prefix(3);
+        firstLine = false;
+        text = Trim(text);
+        if (text.empty() || text.front() == '#' || text.front() == ';')
+            continue;
+        if (text.front() == '[')
+        {
+            const auto close = text.find(']');
+            inTranslations = false;
+            if (close != std::string_view::npos)
+            {
+                const auto remainder = Trim(text.substr(close + 1));
+                inTranslations = Trim(text.substr(1, close - 1)) == "Translations" &&
+                                 (remainder.empty() || remainder.front() == '#' || remainder.front() == ';');
+            }
+            continue;
+        }
+        if (!inTranslations)
+            continue;
+
+        size_t separator = 0;
+        for (; separator < text.size(); ++separator)
+        {
+            if (text[separator] == '\\' && separator + 1 < text.size())
+                ++separator;
+            else if (text[separator] == '=')
+                break;
+        }
+        if (separator == text.size())
+            continue;
+
+        auto key = Unescape(Trim(text.substr(0, separator)));
+        auto value = Unescape(Trim(text.substr(separator + 1)));
+        if (!IsUtf8(key) || !IsUtf8(value))
+            continue;
+
+        // Hidden labels are IDs, not prose. For visible labels the dictionary owns only the
+        // visible part: never let a translated suffix rename or alias an ImGui widget.
+        const auto suffix = key.find("##");
+        if (suffix == 0)
+            continue;
+        const auto translatedSuffix = value.find("##");
+        if (suffix != std::string::npos)
+        {
+            if (translatedSuffix != std::string::npos)
+                value.erase(translatedSuffix);
+            // A trailing '#' would turn an original ## suffix into ### when concatenated.
+            if (value.empty() || value.back() == '#')
+                continue;
+            value.append(key, suffix, std::string::npos);
+        }
+        else if (translatedSuffix != std::string::npos)
+            continue;
+
+        if (HasMatchingFormat(key, value))
+            dictionary.translations.insert_or_assign(std::move(key), std::move(value));
+    }
+    return true;
+}
+
+Dictionary LoadDictionary()
+{
+    Dictionary dictionary;
+    try
+    {
+        const auto dllDirectory = Util::DllPath().parent_path();
+        const auto gameDirectory = Util::ExePath().parent_path();
+        for (const auto* directory : { &dllDirectory, &gameDirectory })
+        {
+            if (directory->empty())
+                continue;
+            if (LoadFile(*directory / L"OptiScaler_zh.ini", dictionary) ||
+                LoadFile(*directory / L"zh_CN.ini", dictionary))
+                return dictionary;
+            if (dllDirectory == gameDirectory)
+                break;
+        }
+    }
+    catch (...)
+    {
+        // An optional language patch must never prevent the menu from opening.
+        // Successfully read entries are still safe to publish, and missing entries fall back.
+    }
+    return dictionary;
+}
+
+const Dictionary& GetDictionary()
+{
+    // This is never reloaded or cleared by MenuCommon::Shutdown. ImGui contexts may be reset
+    // while callers retain pointers to translated labels. Function-local initialization is
+    // thread-safe; all lookups after publication are read-only and allocation-free.
+    static const Dictionary dictionary = LoadDictionary();
+    return dictionary;
+}
+} // namespace
+
+void Localization::Init()
+{
+    (void) GetDictionary();
+}
+
+bool Localization::IsChinese()
+{
+    return GetDictionary().chinese;
+}
+
+const char* Tr(const char* text)
+{
+    if (text == nullptr)
+        return text;
+    const auto& translations = GetDictionary().translations;
+    if (translations.empty())
+        return text;
+    const auto found = translations.find(std::string_view(text));
+    return found == translations.end() ? text : found->second.c_str();
+}

--- a/OptiScaler/misc/Localization.h
+++ b/OptiScaler/misc/Localization.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Localization
+{
+// Loaded once for the DLL lifetime, independently of ImGui context creation/destruction.
+void Init();
+bool IsChinese();
+} // namespace Localization
+
+// Exact, case-sensitive UTF-8 lookup. Returned dictionary strings remain valid until DLL unload;
+// missing keys return text itself. Include the original ##/### suffix in label keys.
+// Translation files must preserve every printf directive verbatim and in the original order.
+const char* Tr(const char* text);

--- a/OptiScaler/shaders/dlssnr/DlssNr_Dx12.cpp
+++ b/OptiScaler/shaders/dlssnr/DlssNr_Dx12.cpp
@@ -22,6 +22,9 @@
 #include <mutex>
 #include <algorithm>
 #include <cstring>
+#include <atomic>
+#include <new>
+#include <vector>
 #include "precompile/DlssNr_Shader.h"
 #include "../output_scaling/OS_Dx12.h"
 
@@ -162,7 +165,12 @@ using PFN_NrSetExtras = void(__cdecl*) (void*, float, ID3D12Resource*, ID3D12Res
 using PFN_NrSetFloatSlot = void(__cdecl*) (int);
 using PFN_NrProbeFloat = void(__cdecl*) (void*, const char*, float, int);
 
-// One per back buffer, so an allocator is never reset while its frame is still in flight.
+// Each layer owns a temporal history; only the two output surfaces are shared.
+struct NrPass
+{
+    void* feature = nullptr;
+    DlssNrResolvedPassSettings tuning {};
+};
 
 struct NrState
 {
@@ -184,24 +192,15 @@ struct NrState
     NVSDK_NGX_Parameter* capabilityParams = nullptr;
     void* feature = nullptr;
 
-    // A feature per extra pass, each with its own temporal history.
-    //
-    // One feature run three times in a frame is told three frames passed with nothing moving between
-    // them, so its history fights every pass after the first -- which is what "loses detail on later
-    // passes" was. Separate features each see one frame per frame, which is the contract they were
-    // built for.
-    //
-    // It is also the only reading that fits the one clue we have about how this is done elsewhere:
-    // that implementation's memory grows with the pass count, and reusing a single feature cannot do
-    // that. A feature apiece can, because each carries its own history.
-    //
-    // Indexed by pass, so [0] is unused and the first extra pass is [1]. Wasting one pointer keeps
-    // every index here equal to the pass number it belongs to.
-    void* passFeature[4] = {};
+    // Additional layers, indexed from zero (entry zero is layer two). Grown only as features are
+    // created, so a large user-supplied count cannot cause an up-front allocation or creation storm.
+    std::vector<NrPass> passFeatures;
+    uint32_t requestedPasses = 1;
 
     // The model cannot read and write one resource, so the frame is staged through these.
     ID3D12Resource* colorCopy = nullptr;
     ID3D12Resource* output = nullptr;
+    ID3D12Resource* outputPingPong = nullptr;
 
     // The frame as the upscaler wrote it. The resolve adds the model's edit to this rather than
     // reconstructing it by inverting the tone curve, which is what turned every light in the frame into
@@ -330,24 +329,17 @@ struct NrState
     float guideMvScaleX = 1.0f;
     float guideMvScaleY = 1.0f;
 
-    // The values the live feature was created with, and when a difference from them was first seen.
-    unsigned int builtPreset = 0;
-    float builtIntensity = 0.0f;
-    unsigned int builtStyle = 0;
-    float builtLocalStructure = 0.0f;
-    float builtLocalTone = 0.0f;
-    float builtSkinStructure = 0.0f;
-    bool builtAutoMask = false;
-    unsigned long long settledAt = 0;
+    DlssNrResolvedPassSettings builtTuning {};
 
-    // Once something fails there is no recovering it mid-session, and retrying every frame turns a
-    // failure into a crash. It stays off and says why.
+    // Latch failures instead of retrying every frame. Retry or an explicit layer-count change
+    // permits another attempt without restarting the game.
     bool failed = false;
     const char* reason = "";
 };
 
 NrState g_nr;
 std::unique_ptr<DlssNr_Dx12> g_compose;
+std::atomic<unsigned int> g_activePassCount { 0 };
 
 // What the pass costs on the GPU, for the breakdown in the overlay.
 std::unique_ptr<GpuTime_Dx12> g_gpuTime;
@@ -642,10 +634,8 @@ void DiscoverFloatSlot(NVSDK_NGX_Parameter* params)
 // clamps linear HDR into an 8-bit texture -- wrong brightness until something forces a rebuild -- or
 // hands CopyResource mismatched formats, which fails silently and makes the whole pass appear to do
 // nothing. So the set is torn down whenever the format it was built for is not the format needed now.
-// Retired model features and surfaces are parked and freed a comfortable number of evaluates later.
-// Releasing them immediately was the device hang: with frame generation the GPU runs several frames
-// behind, this work rides the game's own queue that no module fence covers, and an NGX feature or
-// scratch texture freed under in-flight work kills the device.
+// Retired model features and surfaces follow the existing delayed-release policy. Count this once
+// per frame, never per neural layer: N evaluates do not mean N submissions have retired.
 struct NrRetired
 {
     void* feature = nullptr;
@@ -662,8 +652,8 @@ void ParkNrFeature(void*& feature)
 
     NrRetired r;
     r.feature = feature;
-    feature = nullptr;
     g_nrRetired.push_back(r);
+    feature = nullptr;
 }
 
 void ParkNrResource(ID3D12Resource*& res)
@@ -673,8 +663,8 @@ void ParkNrResource(ID3D12Resource*& res)
 
     NrRetired r;
     r.resource = res;
-    res = nullptr;
     g_nrRetired.push_back(r);
+    res = nullptr;
 }
 
 void TickNrRetired()
@@ -722,11 +712,12 @@ void ReleaseSurfacesIfFormatChanged(DXGI_FORMAT needed)
     ParkNrFeature(g_nr.feature);
 
     // The extras go with it: they were built for this raster and this tuning too.
-    for (void*& f : g_nr.passFeature)
-        ParkNrFeature(f);
+    for (auto& pass : g_nr.passFeatures)
+        ParkNrFeature(pass.feature);
 
     for (ID3D12Resource** r :
-         { &g_nr.output, &g_nr.colorCopy, &g_nr.hdrCopy, &g_nr.colorSmall })
+         { &g_nr.output, &g_nr.outputPingPong, &g_nr.colorCopy, &g_nr.hdrCopy,
+           &g_nr.colorSmall, &g_nr.outputNative })
         ParkNrResource(*r);
 
     g_nr.reset = true;
@@ -1268,10 +1259,6 @@ ID3D12Resource* GetResource(NVSDK_NGX_Parameter* params, const char* a, const ch
     return nullptr;
 }
 
-// A change has to hold still before it is acted on: a slider being dragged reports a new value every
-// frame, and each one would otherwise mean a new model.
-constexpr unsigned long long kSettleFrames = 30;
-
 // The extras the official integration sets: global tone (read at create) and the interface inputs.
 // Written before every create and evaluate, nulls included, so nothing stale ever sits in the block.
 void SetExtras(const Config& cfg, ID3D12Resource* ui, ID3D12Resource* backbuffer, unsigned int uiWidth,
@@ -1286,27 +1273,6 @@ void SetExtras(const Config& cfg, ID3D12Resource* ui, ID3D12Resource* backbuffer
                    uiWidth, uiHeight, bbWidth, bbHeight);
 }
 
-bool TuningMatchesFeature(const Config& cfg)
-{
-    return g_nr.builtPreset == cfg.DlssNrPreset.value_or_default() &&
-           g_nr.builtIntensity == cfg.DlssNrIntensity.value_or_default() &&
-           g_nr.builtStyle == cfg.DlssNrStyle.value_or_default() &&
-           g_nr.builtLocalStructure == cfg.DlssNrLocalStructure.value_or_default() &&
-           g_nr.builtLocalTone == cfg.DlssNrLocalTone.value_or_default() &&
-           g_nr.builtSkinStructure == cfg.DlssNrSkinStructure.value_or_default() &&
-           g_nr.builtAutoMask == cfg.DlssNrAutoMask.value_or_default();
-}
-
-void RecordBuiltTuning(const Config& cfg)
-{
-    g_nr.builtPreset = cfg.DlssNrPreset.value_or_default();
-    g_nr.builtIntensity = cfg.DlssNrIntensity.value_or_default();
-    g_nr.builtStyle = cfg.DlssNrStyle.value_or_default();
-    g_nr.builtLocalStructure = cfg.DlssNrLocalStructure.value_or_default();
-    g_nr.builtLocalTone = cfg.DlssNrLocalTone.value_or_default();
-    g_nr.builtSkinStructure = cfg.DlssNrSkinStructure.value_or_default();
-    g_nr.builtAutoMask = cfg.DlssNrAutoMask.value_or_default();
-}
 
 // Guards the module's state. Every caller is now on the game's render thread, so this is no longer
 // holding two threads apart -- but the D3D11-on-D3D12 bridge enters from its own call site, and the
@@ -1340,6 +1306,26 @@ struct ScopedNrStateEnvelope
     {
         D3D12Hooks::RestoreRoot(cmd);
         D3D12Hooks::SetRootSignatureTracking(true);
+    }
+};
+
+// Creation frames and allocation failures return early too. Restore the caller's output state on
+// every exit; the default UAV arrival adds no barriers to the single-layer path.
+struct ScopedNrOutputState
+{
+    ID3D12GraphicsCommandList* cmd;
+    ID3D12Resource* target;
+    D3D12_RESOURCE_STATES arrival;
+
+    ScopedNrOutputState(ID3D12GraphicsCommandList* commandList, ID3D12Resource* output,
+                        D3D12_RESOURCE_STATES state) : cmd(commandList), target(output), arrival(state)
+    {
+        Barrier(cmd, target, arrival, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    }
+
+    ~ScopedNrOutputState()
+    {
+        Barrier(cmd, target, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, arrival);
     }
 };
 
@@ -1495,11 +1481,35 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
 {
     std::lock_guard<std::mutex> nrLock(g_nrMutex);
     const Config& cfg = *Config::Instance();
+    const uint32_t passes = std::max(1u, cfg.DlssNrPasses.value_or_default());
+    const DlssNrResolvedPassSettings firstTuning = cfg.GetDlssNrPassSettings(0);
+    g_activePassCount.store(0, std::memory_order_relaxed);
+
+    // A deliberate count change is also a recovery action (for example, reducing layers after an
+    // out-of-memory error). Never retry an unchanged failing request every frame.
+    if (g_nr.requestedPasses != passes)
+    {
+        g_nr.requestedPasses = passes;
+        g_nr.failed = false;
+        g_nr.reason = "";
+        g_nr.reset = true;
+    }
+
+    if (cmdList != nullptr && output != nullptr)
+        TickNrRetired();
 
     if (g_nr.failed || cmdList == nullptr || colour == nullptr || depth == nullptr ||
         motion == nullptr || output == nullptr)
     {
         ReportSkipOnce(g_nr.failed ? "it already failed this session" : "a resource was missing");
+        return;
+    }
+
+    if (cfg.DlssNrUseProxy.value_or_default() &&
+        (passes > 1 || cfg.DlssNrIndividualPassSettings.value_or_default()))
+    {
+        g_nr.failed = true;
+        g_nr.reason = "Layer settings need the normal rendering path. Turn off UseProxy in the configuration.";
         return;
     }
 
@@ -1516,7 +1526,7 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
             ? (D3D12_RESOURCE_STATES) Config::Instance()->OutputResourceBarrier.value()
             : D3D12_RESOURCE_STATE_UNORDERED_ACCESS;
 
-    Barrier(cmdList, target, outputArrival, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    ScopedNrOutputState outputState(cmdList, target, outputArrival);
 
     ID3D12Device* device = nullptr;
 
@@ -1664,41 +1674,57 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
     const bool resolutionChanged = g_nr.width != width || g_nr.height != height ||
                                    g_nr.workWidth != workWidth || g_nr.workHeight != workHeight;
 
-    // The model reads its tuning once, while the feature is built, so a changed setting only takes
-    // effect when the feature is rebuilt. TuningMatchesFeature was written to notice that and then
-    // never called, which is why every one of these controls appeared to do nothing until something
-    // else -- a resolution change -- happened to force a rebuild by accident.
-    const bool tuningChanged = !TuningMatchesFeature(cfg);
-
-    if (g_nr.feature != nullptr && (resolutionChanged || tuningChanged))
+    // Only rebuild the layers whose creation-time tuning changed. Downstream histories reset on
+    // any rebuild because their input changes, but their expensive features need not be recreated.
+    if (resolutionChanged)
     {
-        // Parked rather than released: with frame generation the GPU can still be several frames
-        // deep in work that references all of it.
         ParkNrFeature(g_nr.feature);
+        for (auto& pass : g_nr.passFeatures)
+            ParkNrFeature(pass.feature);
 
-        for (void*& f : g_nr.passFeature)
-            ParkNrFeature(f);
+        for (ID3D12Resource** resource :
+             { &g_nr.output, &g_nr.outputPingPong, &g_nr.colorCopy, &g_nr.hdrCopy,
+               &g_nr.colorSmall, &g_nr.outputNative })
+            ParkNrResource(*resource);
+        g_nr.reset = true;
+    }
+    else if (g_nr.feature != nullptr && g_nr.builtTuning != firstTuning)
+    {
+        ParkNrFeature(g_nr.feature);
+        g_nr.reset = true;
+    }
 
-        // Only a resolution change invalidates the scratch textures. Tuning does not, and throwing
-        // them away for it would mean a reallocation every time a slider moves.
-        if (resolutionChanged)
+    const size_t extraPasses = static_cast<size_t>(passes - 1);
+    if (g_nr.passFeatures.size() > extraPasses)
+    {
+        for (size_t i = extraPasses; i < g_nr.passFeatures.size(); ++i)
+            ParkNrFeature(g_nr.passFeatures[i].feature);
+        g_nr.passFeatures.resize(extraPasses);
+    }
+
+    for (size_t i = 0; i < g_nr.passFeatures.size(); ++i)
+    {
+        auto& pass = g_nr.passFeatures[i];
+        if (pass.feature != nullptr && pass.tuning != cfg.GetDlssNrPassSettings(static_cast<uint32_t>(i + 1)))
         {
-            ParkNrResource(g_nr.output);
-            ParkNrResource(g_nr.colorCopy);
-            ParkNrResource(g_nr.hdrCopy);
-            ParkNrResource(g_nr.colorSmall);
-            ParkNrResource(g_nr.outputNative);
+            ParkNrFeature(pass.feature);
+            g_nr.reset = true;
         }
     }
 
+    if (passes == 1)
+        ParkNrResource(g_nr.outputPingPong);
+    else if (g_nr.outputPingPong == nullptr)
+        g_nr.outputPingPong = CreateScratch(device, desc.Format, workWidth, workHeight);
+
     if (g_nr.output == nullptr)
-    {
         g_nr.output = CreateScratch(device, desc.Format, workWidth, workHeight);
+    if (g_nr.colorCopy == nullptr)
         g_nr.colorCopy = CreateScratch(device, desc.Format, width, height);
+    if (g_nr.hdrCopy == nullptr)
         g_nr.hdrCopy = CreateScratch(device, desc.Format, width, height);
-        g_nr.workWidth = workWidth;
-        g_nr.workHeight = workHeight;
-    }
+    g_nr.workWidth = workWidth;
+    g_nr.workHeight = workHeight;
 
     if (reduced && g_nr.colorSmall == nullptr)
         g_nr.colorSmall = CreateScratch(device, desc.Format, workWidth, workHeight);
@@ -1706,6 +1732,16 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
     // The down-leg target is native (the answer is brought back to frame size before the resolve).
     if (workScale > 1.0f && g_nr.outputNative == nullptr)
         g_nr.outputNative = CreateScratch(device, desc.Format, width, height);
+
+    if (g_nr.output == nullptr || g_nr.colorCopy == nullptr || g_nr.hdrCopy == nullptr ||
+        (passes > 1 && g_nr.outputPingPong == nullptr) || (reduced && g_nr.colorSmall == nullptr))
+    {
+        g_nr.failed = true;
+        g_nr.reason = "Not enough graphics memory. Reduce layers or model resolution, then retry.";
+        LOG_ERROR("DLSS-NR: could not allocate surfaces for {} layers at {}x{}", passes, workWidth, workHeight);
+        device->Release();
+        return;
+    }
 
     if (g_nr.meter == nullptr)
     {
@@ -1740,8 +1776,73 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
             LOG_INFO("DLSS-NR: white point meter up, {}x{} tiles", kDlssNrMeterGrid, kDlssNrMeterGrid);
     }
 
-    if (g_nr.feature == nullptr && g_nr.output != nullptr && g_nr.colorCopy != nullptr &&
-        g_nr.hdrCopy != nullptr)
+    // On an engine that needs its compute state put back -- the bindless quirks -- the envelope can
+    // only restore what was captured. If nothing was captured for this list, the upscaler decided
+    // touching state was unsafe this frame, and binding the pass now would leave state the envelope
+    // cannot clean up. So on those games, skip the frame rather than corrupt it. Ordinary games do
+    // not require restore, so they are unaffected and the pass runs as before.
+    const bool restoreRequired = cfg.RestoreComputeSignature.value_or_default() ||
+                                 cfg.RestoreGraphicSignature.value_or_default();
+
+    if (restoreRequired && !D3D12Hooks::CanRestoreRootSignature(cmdList))
+    {
+        ReportSkipOnce("the upscaler could not restore state this frame");
+
+        // The device reference taken at the top of this function is released on every other path out.
+        // It was not released here, and this is the one path a bindless game takes every single frame
+        // -- so the game that most needed this skip was also leaking a device reference per frame.
+        device->Release();
+        return;
+    }
+
+    // From here on the pass binds its own root signature, heaps and pipeline. Everything below runs
+    // inside the envelope so the game's compute state is restored no matter which way this returns.
+    ScopedNrStateEnvelope stateEnvelope(cmdList);
+
+    // At most one feature is created in a frame, including during an N-layer rebuild. This avoids
+    // a burst of NGX allocations for arbitrary counts. No layer evaluates on ANY creation frame.
+    void** featureToCreate = nullptr;
+    DlssNrResolvedPassSettings* tuningToRecord = nullptr;
+    uint32_t createIndex = 0;
+    if (g_nr.feature == nullptr)
+    {
+        featureToCreate = &g_nr.feature;
+        tuningToRecord = &g_nr.builtTuning;
+    }
+    else
+    {
+        for (size_t i = 0; i < g_nr.passFeatures.size(); ++i)
+        {
+            if (g_nr.passFeatures[i].feature == nullptr)
+            {
+                featureToCreate = &g_nr.passFeatures[i].feature;
+                tuningToRecord = &g_nr.passFeatures[i].tuning;
+                createIndex = static_cast<uint32_t>(i + 1);
+                break;
+            }
+        }
+
+        if (featureToCreate == nullptr && g_nr.passFeatures.size() < extraPasses)
+        {
+            try
+            {
+                g_nr.passFeatures.emplace_back();
+            }
+            catch (const std::bad_alloc&)
+            {
+                g_nr.failed = true;
+                g_nr.reason = "Not enough memory for more layers. Reduce layers, then retry.";
+                device->Release();
+                return;
+            }
+            auto& pass = g_nr.passFeatures.back();
+            featureToCreate = &pass.feature;
+            tuningToRecord = &pass.tuning;
+            createIndex = static_cast<uint32_t>(g_nr.passFeatures.size());
+        }
+    }
+
+    if (featureToCreate != nullptr)
     {
         auto snippet = Util::FindFilePath(g_dllDir, "nvngx_dlssnr.dll");
 
@@ -1757,30 +1858,29 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
             return;
         }
 
+        const auto tuning = createIndex == 0 ? firstTuning : cfg.GetDlssNrPassSettings(createIndex);
         SetExtras(cfg, nullptr, nullptr, 0, 0, 0, 0);
-        g_nr.feature =
+        *featureToCreate =
             g_nr.create(snippet->wstring().c_str(), State::Instance().NVNGX_ApplicationDataPath.c_str(),
                         device, cmdList, g_nr.capabilityParams, workWidth, workHeight,
-                        (int) cfg.DlssNrPreset.value_or_default(),
-                        cfg.DlssNrIntensity.value_or_default(), (int) cfg.DlssNrStyle.value_or_default(),
-                        cfg.DlssNrLocalStructure.value_or_default(), cfg.DlssNrLocalTone.value_or_default(),
-                        cfg.DlssNrSkinStructure.value_or_default(),
-                        cfg.DlssNrAutoMask.value_or_default() ? 1 : 0,
-                        // UI correction at the model's own default: with no UI layer fed to it there
-                        // is nothing for it to correct.
-                        1);
+                        static_cast<int>(tuning.Preset), tuning.Intensity, static_cast<int>(tuning.Style),
+                        tuning.LocalStructure, tuning.LocalTone, tuning.SkinStructure,
+                        tuning.AutoMask ? 1 : 0, 1);
 
-        if (g_nr.feature == nullptr)
+        if (*featureToCreate == nullptr ||
+            (g_nr.lastCreate != nullptr && *g_nr.lastCreate != NVSDK_NGX_Result_Success))
         {
+            // Even an unsuccessful creation may have recorded GPU work against a returned handle.
+            ParkNrFeature(*featureToCreate);
             g_nr.failed = true;
-            g_nr.reason = "the model would not initialise";
+            g_nr.reason = "A neural rendering layer could not start. Reduce layers or model resolution, then retry.";
             const auto initResult = (unsigned int) (g_nr.lastInit != nullptr ? *g_nr.lastInit : 0);
             const auto createResult = (unsigned int) (g_nr.lastCreate != nullptr ? *g_nr.lastCreate : 0);
 
             // Cast before formatting. These are ints, and "0x{:X}" on a negative int prints
             // 0x-452FFFFF, which no one can decode back to 0xBAD00001.
-            LOG_ERROR("DLSS-NR create failed: init 0x{:X} ({}), create 0x{:X} ({})", initResult,
-                      NgxResultName(initResult), createResult, NgxResultName(createResult));
+            LOG_ERROR("DLSS-NR layer {} create failed: init 0x{:X} ({}), create 0x{:X} ({})",
+                      createIndex + 1, initResult, NgxResultName(initResult), createResult, NgxResultName(createResult));
             device->Release();
             return;
         }
@@ -1788,22 +1888,16 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
         g_nr.width = width;
         g_nr.height = height;
         g_nr.reset = true;
-        RecordBuiltTuning(cfg);
-        LOG_INFO("DLSS-NR running at {}x{}, guides {}x{} (preset {}, intensity {}, style {})", width,
-                 height, guideWidth, guideHeight, g_nr.builtPreset, g_nr.builtIntensity, g_nr.builtStyle);
+        *tuningToRecord = tuning;
+        LOG_INFO("DLSS-NR prepared layer {}/{} at {}x{} (preset {}, intensity {}, style {})",
+                 createIndex + 1, passes, workWidth, workHeight, tuning.Preset, tuning.Intensity, tuning.Style);
 
-        // Creating and evaluating a feature in the same command list is the dice-roll that hung the
-        // GPU (every crash died on a creation frame). The creation goes through the game's own submit
-        // first; the first evaluate happens next frame. One frame without the model is invisible.
+        // Creation records GPU work into the game's list. Return the untouched upscaled frame and
+        // let that list be submitted; the first evaluate can only happen on a subsequent frame.
         device->Release();
         return;
     }
 
-    if (g_nr.feature == nullptr)
-    {
-        device->Release();
-        return;
-    }
 
     // The upscaler has just written this, so it is a UAV. The model needs it readable.
     // Whether the buffer the upscaler just wrote is linear HDR or an already tone-mapped picture is not
@@ -1842,7 +1936,6 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
     // of the game's exposure rather than a number worth asking anyone to guess: measured means of 0.065,
     // 1.8 and 185 have all been seen in this one game.
     ++g_frames;
-    TickNrRetired();
     CheckCaptureTrigger();
 
     if (g_captureWriteAtFrame != 0 && g_frames >= g_captureWriteAtFrame)
@@ -1865,29 +1958,6 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
     // defeated. That branch hands back `originalLuma - proxyLuma`, the headroom the proxy could not
     // represent -- it exists precisely because the proxy is meant to clip. Normalising the highlights
     // away first leaves it nothing to give back.
-
-    // On an engine that needs its compute state put back -- the bindless quirks -- the envelope can
-    // only restore what was captured. If nothing was captured for this list, the upscaler decided
-    // touching state was unsafe this frame, and binding the pass now would leave state the envelope
-    // cannot clean up. So on those games, skip the frame rather than corrupt it. Ordinary games do
-    // not require restore, so they are unaffected and the pass runs as before.
-    const bool restoreRequired = cfg.RestoreComputeSignature.value_or_default() ||
-                                 cfg.RestoreGraphicSignature.value_or_default();
-
-    if (restoreRequired && !D3D12Hooks::CanRestoreRootSignature(cmdList))
-    {
-        ReportSkipOnce("the upscaler could not restore state this frame");
-
-        // The device reference taken at the top of this function is released on every other path out.
-        // It was not released here, and this is the one path a bindless game takes every single frame
-        // -- so the game that most needed this skip was also leaking a device reference per frame.
-        device->Release();
-        return;
-    }
-
-    // From here on the pass binds its own root signature, heaps and pipeline. Everything below runs
-    // inside the envelope so the game's compute state is restored no matter which way this returns.
-    ScopedNrStateEnvelope stateEnvelope(cmdList);
 
     if (g_gpuTime == nullptr)
         g_gpuTime = std::make_unique<GpuTime_Dx12>(device);
@@ -2048,11 +2118,21 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
 
     Barrier(cmdList, target, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
-    DispatchPass(cmdList, encodeParams, target, nullptr, nullptr, nullptr, exposureTex,
-                        g_nr.colorCopy, g_nr.hdrCopy);
+    const bool encoded = DispatchPass(cmdList, encodeParams, target, nullptr, nullptr, nullptr,
+                                      exposureTex, g_nr.colorCopy, g_nr.hdrCopy);
 
     Barrier(cmdList, target, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    if (!encoded)
+    {
+        g_nr.failed = true;
+        g_nr.reason = "The neural rendering image could not be composed. Retry to rebuild it.";
+        g_nr.reset = true;
+        if (g_gpuTime != nullptr)
+            g_gpuTime->End(cmdList);
+        device->Release();
+        return;
+    }
     // The transitions double as the wait for the encode's writes.
     Barrier(cmdList, g_nr.colorCopy, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
@@ -2062,6 +2142,26 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
 
     Barrier(cmdList, g_nr.hdrCopy, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
             D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+
+    // Every successful transition must be undone even if a later stage fails. In particular, a
+    // Retry must never copy into a guide clone that an aborted frame left in the readable state.
+    const auto restoreEncodedInputs = [&](bool smallReadable, ID3D12Resource* depthRead = nullptr,
+                                           ID3D12Resource* motionRead = nullptr)
+    {
+        if (depthRead != nullptr && depthRead == g_nr.depthClone)
+            Barrier(cmdList, depthRead, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                    D3D12_RESOURCE_STATE_COPY_DEST);
+        if (motionRead != nullptr && motionRead == g_nr.motionClone)
+            Barrier(cmdList, motionRead, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                    D3D12_RESOURCE_STATE_COPY_DEST);
+        if (smallReadable)
+            Barrier(cmdList, g_nr.colorSmall, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                    D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+        Barrier(cmdList, g_nr.hdrCopy, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+        Barrier(cmdList, g_nr.colorCopy, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+    };
 
     // Below full resolution the model is shown a filtered shrink of the proxy; the edit it returns is
     // enlarged during the resolve while the frame underneath stays full size and untouched.
@@ -2121,8 +2221,18 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
             down.Mode = DlssNrMode_Downsample;
             down.Width = workWidth;
             down.Height = workHeight;
-            DispatchPass(cmdList, down, modelInput, nullptr, nullptr, nullptr, nullptr,
-                                g_nr.colorSmall, nullptr);
+            if (!DispatchPass(cmdList, down, modelInput, nullptr, nullptr, nullptr, nullptr,
+                              g_nr.colorSmall, nullptr))
+            {
+                restoreEncodedInputs(false);
+                g_nr.failed = true;
+                g_nr.reason = "The neural rendering image could not be composed. Retry to rebuild it.";
+                g_nr.reset = true;
+                if (g_gpuTime != nullptr)
+                    g_gpuTime->End(cmdList);
+                device->Release();
+                return;
+            }
             Barrier(cmdList, g_nr.colorSmall, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                     D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
         }
@@ -2141,7 +2251,10 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
         g_nr.failed = true;
         g_nr.reason = "the game's depth or motion vectors could not be made readable";
         LOG_ERROR("DLSS-NR unavailable: {}", g_nr.reason);
-        Barrier(cmdList, target, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, outputArrival);
+        g_nr.reset = true;
+        restoreEncodedInputs(reduced, depthIn, motionIn);
+        if (g_gpuTime != nullptr)
+            g_gpuTime->End(cmdList);
         device->Release();
         return;
     }
@@ -2175,7 +2288,9 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
                       proxyResult, NgxResultName(proxyResult));
         }
 
-        Barrier(cmdList, target, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, outputArrival);
+        restoreEncodedInputs(reduced, depthIn, motionIn);
+        if (g_gpuTime != nullptr)
+            g_gpuTime->End(cmdList);
         device->Release();
         return;
     }
@@ -2183,21 +2298,45 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
     if (g_ngxTime != nullptr)
         g_ngxTime->Start(cmdList);
 
-    // Multi-pass was removed: re-feeding the model its own output re-opened the same-command-list
-    // feature-creation hang, and the colour core is not settled enough to build on. One evaluate.
-    const int result = g_nr.evaluate(
+    // Layer one is the original single-pass evaluate. All features were prepared on earlier
+    // frames; the cascade below only evaluates, and each feature advances its own history once.
+    int result = g_nr.evaluate(
         cmdList, g_nr.feature, g_nr.capabilityParams, modelInput, depthIn, motionIn, g_nr.output,
         workWidth, workHeight, guideWidth, guideHeight, g_nr.guideDepthInverted ? 1 : 0,
-        g_nr.reset ? 1 : 0, cfg.DlssNrIntensity.value_or_default(),
-        (int) cfg.DlssNrStyle.value_or_default(), cfg.DlssNrLocalStructure.value_or_default(),
-        cfg.DlssNrLocalTone.value_or_default(), cfg.DlssNrSkinStructure.value_or_default(),
-        cfg.DlssNrAutoMask.value_or_default() ? 1 : 0, g_nr.guideMvScaleX * mvToWork,
+        g_nr.reset ? 1 : 0, firstTuning.Intensity, static_cast<int>(firstTuning.Style),
+        firstTuning.LocalStructure, firstTuning.LocalTone, firstTuning.SkinStructure,
+        firstTuning.AutoMask ? 1 : 0, g_nr.guideMvScaleX * mvToWork,
         g_nr.guideMvScaleY * mvToWork);
+
+    ID3D12Resource* finalOutput = g_nr.output;
+    uint32_t evaluatedPasses = result == NVSDK_NGX_Result_Success ? 1u : 0u;
+    for (size_t i = 0; result == NVSDK_NGX_Result_Success && i < g_nr.passFeatures.size(); ++i)
+    {
+        const auto& pass = g_nr.passFeatures[i];
+        const auto& tuning = pass.tuning;
+        ID3D12Resource* nextOutput = finalOutput == g_nr.output ? g_nr.outputPingPong : g_nr.output;
+
+        // The transition orders the previous write before the next layer's read. The other surface
+        // is already UAV: each consumed input is returned to UAV before it can be reused as output.
+        Barrier(cmdList, finalOutput, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+                D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
+        result = g_nr.evaluate(
+            cmdList, pass.feature, g_nr.capabilityParams, finalOutput, depthIn, motionIn, nextOutput,
+            workWidth, workHeight, guideWidth, guideHeight, g_nr.guideDepthInverted ? 1 : 0,
+            g_nr.reset ? 1 : 0, tuning.Intensity, static_cast<int>(tuning.Style),
+            tuning.LocalStructure, tuning.LocalTone, tuning.SkinStructure, tuning.AutoMask ? 1 : 0,
+            g_nr.guideMvScaleX * mvToWork, g_nr.guideMvScaleY * mvToWork);
+        Barrier(cmdList, finalOutput, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+                D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
+        finalOutput = nextOutput;
+        if (result == NVSDK_NGX_Result_Success)
+            ++evaluatedPasses;
+    }
 
     if (g_ngxTime != nullptr)
         g_ngxTime->End(cmdList);
 
-    g_nr.reset = false;
+    g_nr.reset = result != NVSDK_NGX_Result_Success;
 
     // Supersampling probe: report the model working ABOVE native so a test log tells us whether NGX even
     // accepts a super-native evaluate and what it returns. Once per working-size change, or on any error.
@@ -2213,10 +2352,10 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
         }
     }
 
-    // Once, a few seconds in, so it lands after the values have been written at least once.
+    // This legacy readback describes the master feature only, not a shared block after N layers.
     static bool tuningReported = false;
 
-    if (!tuningReported && g_frames > 240)
+    if (!tuningReported && g_frames > 240 && passes == 1 && !cfg.DlssNrIndividualPassSettings.value_or_default())
     {
         tuningReported = true;
 
@@ -2338,7 +2477,7 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
                      composeNow.workH, composeNow.debugView, composeNow.compareMode);
         }
 
-        Barrier(cmdList, g_nr.output, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
+        Barrier(cmdList, finalOutput, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                 D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
 
         // Supersampling down-leg. Average the Nx model answer back to native with the chosen filter, so
@@ -2346,10 +2485,10 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
         // not the single bilinear tap the Nx answer would otherwise get in the resolve (which aliases
         // the model's detail into noise, the "noisier above 100%" the probe showed). On success the
         // resolve reads the native proxy (colorCopy) and native answer (outputNative); on failure it
-        // falls back to the Nx pair. g_nr.output is NPSR here; outputNative is UAV from last frame.
+        // falls back to the Nx pair. finalOutput is NPSR here; outputNative is UAV from last frame.
         bool superDownOk = false;
         if (workScale > 1.0f && g_nr.superDown != nullptr && g_nr.outputNative != nullptr &&
-            g_nr.superDown->Dispatch(cmdList, g_nr.output, g_nr.outputNative))
+            g_nr.superDown->Dispatch(cmdList, finalOutput, g_nr.outputNative))
         {
             Barrier(cmdList, g_nr.outputNative, D3D12_RESOURCE_STATE_UNORDERED_ACCESS,
                     D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
@@ -2357,11 +2496,19 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
         }
 
         ID3D12Resource* resolveProxy = superDownOk ? g_nr.colorCopy : modelInput;
-        ID3D12Resource* resolveAnswer = superDownOk ? g_nr.outputNative : g_nr.output;
+        ID3D12Resource* resolveAnswer = superDownOk ? g_nr.outputNative : finalOutput;
 
-        DispatchPass(cmdList, resolveParams, resolveProxy, resolveAnswer, g_nr.hdrCopy, motionIn,
-                            exposureTex, target, nullptr);
-        Barrier(cmdList, g_nr.output, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
+        const bool composed = DispatchPass(cmdList, resolveParams, resolveProxy, resolveAnswer,
+                                           g_nr.hdrCopy, motionIn, exposureTex, target, nullptr);
+        if (composed)
+            g_activePassCount.store(evaluatedPasses, std::memory_order_relaxed);
+        else
+        {
+            g_nr.failed = true;
+            g_nr.reason = "The neural rendering image could not be composed. Retry to rebuild it.";
+            g_nr.reset = true;
+        }
+        Barrier(cmdList, finalOutput, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                 D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
         if (superDownOk)
@@ -2372,7 +2519,7 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
         // upscaler produced it, and the edited frame is the output itself. The write happens a few
         // frames later, once the GPU is certainly past these copies -- this path has no fence of its
         // own.
-        if (g_capture.isActive())
+        if (composed && g_capture.isActive())
         {
             g_capture.record(cmdList, device, g_nr.colorCopy,
                              D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE, target,
@@ -2385,9 +2532,9 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
     else
     {
         g_nr.failed = true;
-        g_nr.reason = "the model refused to run";
-        LOG_ERROR("DLSS-NR evaluate returned 0x{:X} ({}), disabling for this session", (uint32_t) result,
-                  NgxResultName((unsigned int) result));
+        g_nr.reason = "A neural rendering layer stopped. Reduce layers or change its settings, then retry.";
+        LOG_ERROR("DLSS-NR layer {}/{} evaluate returned 0x{:X} ({})", evaluatedPasses + 1, passes,
+                  static_cast<uint32_t>(result), NgxResultName(static_cast<unsigned int>(result)));
     }
 
     Barrier(cmdList, g_nr.hdrCopy, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
@@ -2431,16 +2578,13 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
         }
     }
 
-    // Put any guide clones back where the next frame's copy expects to find them.
-    // A clone left in NON_PIXEL_SHADER_RESOURCE by a frozen frame was never transitioned back to
-    // COPY_DEST, because a frozen frame does not copy. Putting it back unconditionally would be a
-    // barrier from a state it is not in, so the frozen case is skipped here and picked up by the
-    // first live frame after the toggle goes off -- which is a copy, and copies transition it.
-    if (g_nr.depthClone != nullptr)
+    // Only clones actually read this frame changed state. A guide may have switched from a
+    // typeless texture to a directly-readable one while its old clone remains allocated.
+    if (depthIn == g_nr.depthClone)
         Barrier(cmdList, g_nr.depthClone, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                 D3D12_RESOURCE_STATE_COPY_DEST);
 
-    if (g_nr.motionClone != nullptr)
+    if (motionIn == g_nr.motionClone)
         Barrier(cmdList, g_nr.motionClone, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
                 D3D12_RESOURCE_STATE_COPY_DEST);
 
@@ -2452,9 +2596,6 @@ void DlssNr_Dx12::Dispatch(ID3D12GraphicsCommandList* cmdList, ID3D12Resource* c
     Barrier(cmdList, g_nr.colorCopy, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE,
             D3D12_RESOURCE_STATE_UNORDERED_ACCESS);
 
-    // Hand the output back in the state the upscaler and the game expect.
-    Barrier(cmdList, target, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, outputArrival);
-
     device->Release();
 }
 
@@ -2462,6 +2603,8 @@ namespace DlssNr
 {
 void RetryAfterFailure()
 {
+    std::lock_guard<std::mutex> nrLock(g_nrMutex);
+    g_activePassCount.store(0, std::memory_order_relaxed);
     g_nr.failed = false;
     g_nr.reason = "";
     g_nr.reset = true;
@@ -2476,6 +2619,8 @@ void RetryAfterFailure()
 void EvaluateAfterUpscale(ID3D12GraphicsCommandList* cmdList, NVSDK_NGX_Parameter* params,
                           ID3D12CommandQueue* timingQueue)
 {
+    // Missing resources below must not leave the previous frame's active count on the menu.
+    g_activePassCount.store(0, std::memory_order_relaxed);
     if (!Config::Instance()->DlssNrEnabled.value_or_default())
     {
         ReportSkipOnce("it is switched off");
@@ -2814,9 +2959,22 @@ CalibrationReading Calibration()
     return r;
 }
 
-bool IsRunning() { return g_nr.feature != nullptr && !g_nr.failed; }
+bool IsRunning()
+{
+    std::lock_guard<std::mutex> nrLock(g_nrMutex);
+    return g_nr.feature != nullptr && !g_nr.failed;
+}
 
-const char* FailureReason() { return g_nr.failed ? g_nr.reason : ""; }
+unsigned int ActivePassCount()
+{
+    return g_activePassCount.load(std::memory_order_relaxed);
+}
+
+const char* FailureReason()
+{
+    std::lock_guard<std::mutex> nrLock(g_nrMutex);
+    return g_nr.failed ? g_nr.reason : "";
+}
 
 // What the game offers by way of exposure, and what has been read from it. For the menu, so a user
 // can see whether this game supplies one at all without having to read a log.
@@ -2863,12 +3021,19 @@ void Shutdown()
 
     g_nr.feature = nullptr;
 
-    for (void*& f : g_nr.passFeature)
+    for (auto& pass : g_nr.passFeatures)
     {
-        if (f != nullptr && g_nr.release != nullptr)
-            g_nr.release(f);
+        if (pass.feature != nullptr && g_nr.release != nullptr)
+            g_nr.release(pass.feature);
+    }
+    g_nr.passFeatures.clear();
+    g_activePassCount.store(0, std::memory_order_relaxed);
+    g_nr.reset = true;
 
-        f = nullptr;
+    if (g_nr.outputPingPong != nullptr)
+    {
+        g_nr.outputPingPong->Release();
+        g_nr.outputPingPong = nullptr;
     }
 
     if (g_nr.output != nullptr)

--- a/OptiScaler/shaders/dlssnr/DlssNr_Dx12.h
+++ b/OptiScaler/shaders/dlssnr/DlssNr_Dx12.h
@@ -74,9 +74,9 @@ class DlssNr_Dx12 : public Shader_Dx12, public DlssNr_Common
 
     // The pass. Resources in, and nothing read from anywhere the caller cannot see.
     //
-    // This is the whole filter: it brings the model up if it is not already, builds the feature and
-    // rebuilds it when the tuning or the resolution changes, evaluates it, and runs the compute passes
-    // that show it the frame and bring its answer back. One call, like any other shader here.
+    // This is the whole filter: it prepares one independent feature per requested layer, waits a
+    // frame after creation, then cascades the model through two alternating outputs. The proxy and
+    // untouched original are retained for one final resolve. One layer uses the original path.
     //
     // Sizes come from the resources. Everything the pass cannot work out for itself is in
     // DlssNrFrameInfo; everything the user chose stays in Config. colour and output may be the same
@@ -87,7 +87,7 @@ class DlssNr_Dx12 : public Shader_Dx12, public DlssNr_Common
 
     // Records one pass. Resources that a given mode does not read may be null; a stand-in is bound in
     // their place so every descriptor in the table is valid.
-    // One compute pass. The public entry below drives three of these plus the model.
+    // Neural layers call NGX directly; adding layers does not consume extra shader heap slots.
     bool DispatchPass(ID3D12GraphicsCommandList* InCmdList, const DlssNrConstants& InConstants,
                   ID3D12Resource* InSource, ID3D12Resource* InModel, ID3D12Resource* InOriginal,
                   ID3D12Resource* InMotion,

--- a/OptiScaler_zh.ini
+++ b/OptiScaler_zh.ini
@@ -1,0 +1,359 @@
+# OptiScaler 简体中文外挂语言补丁
+# 编码: UTF-8
+# 说明: 放置于游戏目录 / OptiScaler.dll 同级目录下生效
+# 搜索顺序：DLL 目录的 OptiScaler_zh.ini、zh_CN.ini，然后游戏程序目录中的同名文件。
+# 首个可读文件生效；修改后需重新启动游戏。删除补丁即可恢复英文菜单。
+# 键区分大小写；整行 # 或 ; 为注释。用 \n 表示换行，\t 表示制表符，\s 保留首尾空格，\\ 表示反斜线，\= 表示键中的等号。
+# 格式串中的 %s、%u、%.1f、%% 等占位符须逐字保留原顺序；不兼容的翻译会被忽略。
+# 标签键含 ## 或 ### 时须写完整；引擎自动保留原标签的隐藏标识后缀。
+
+[Translations]
+# === DLSS Neural Rendering (神经渲染) ===
+DLSS Neural Rendering = DLSS 5 神经渲染 (Neural Rendering)
+Enable Neural Rendering = 启用神经渲染
+Apply the model = 应用模型效果
+Can be toggled with a key -- bind it under Keybinds, "Neural Rendering". = 可绑定快捷键实时切换（在“按键绑定”中的“Neural Rendering”设置）。
+Status: Active = 运行状态：生效中
+Status: Active (%d-pass stacked) = 运行状态：已生效 (%d 层级联叠加)
+Status: Idle = 运行状态：空闲
+Status: Waiting for upscaler = 运行状态：等待超分器输入
+Status: Model not found = 运行状态：未找到 nvngx_dlssnr.dll 模型文件
+
+# === 多层级联叠加设置 ===
+Passes (Layers) = 级联叠加层数 (Passes)
+Individual layer settings = 单独设置每层配置 (独立调优)
+Enable individual pass configuration = 开启每层参数独立调节
+Pass 1 Configuration = 第 1 层参数 (Pass 1)
+Pass 2 Configuration = 第 2 层参数 (Pass 2)
+Pass 3 Configuration = 第 3 层参数 (Pass 3)
+Pass 4 Configuration = 第 4 层参数 (Pass 4)
+Use Master Settings = 使用全局通用配置
+Layer Intensity = 本层细节强度
+Layer Style = 本层风格预设
+Layer Local Structure = 本层局部结构细节
+Layer Local Tone = 本层局部色调对比
+Layer Skin Structure = 本层皮肤纹理保护
+
+# === 细节与强度控制 ===
+How much of it lands = 细节强度与着色
+Detail strength = 细节强度 (Detail Strength)
+Colour strength = 色彩强度 (Colour Strength)
+Max Ratio = 像素亮度比例保护上限
+
+# === 模型核心配置 ===
+Model = 模型核心参数 (Model)
+Read when the model is built, so a change rebuilds it after a moment. = 修改后将自动重新构建模型实例，稍候片刻生效。
+Preset = 渲染预设 (Preset)
+Intensity = 模型细节推演强度 (Intensity)
+Style = 画面风格特征 (Style)
+Local structure = 局部结构纹理强度 (Local Structure)
+Local tone = 局部明暗对比细节 (Local Tone)
+Skin structure = 皮肤材质保护度 (Skin Structure)
+Auto mask = 自动透明度与动态蒙版 (Auto Mask)
+Working resolution = 模型运行工作分辨率 (Working Scale)
+
+# === 色彩与曝光 ===
+Colour = 色彩与曝光校准 (Colour)
+Paper white = 纸白亮度基准 (Paper White)
+White point source = 白点测量源 (White Point Source)
+Trim (x the game's exposure) = 曝光微调比率 (Trim)
+Use game exposure = 追踪游戏原生曝光参数
+
+# === 画面对比与测试 ===
+Compare = 画面对比与实时 A/B (Compare)
+Hold frame = 冻结当前帧 (用于静止比对)
+Compare mode = 对比视图模式
+Side by side = 左右并排比对
+Wipe = 卷帘拉线比对
+Debug view = 调试可视化通道
+
+# === 基础菜单与通用设置 ===
+General = 通用设置
+Upscaler = 超分引擎 (Upscaler)
+Upscaler Inputs = 超分器输入参数
+Frame Generation = 帧生成技术 (Frame Generation)
+Advanced DLSS Settings = DLSS 高级配置
+Advanced DLSSD Settings = DLSS 降噪高级配置
+Advanced FG Settings = 帧生成高级配置
+Extended FSR FG Settings = FSR 帧生成扩展配置
+Extended XeFG Settings = XeSS 帧生成扩展配置
+Advanced OptiFG Settings = OptiFG 帧生成高级配置
+V-Sync Settings = 垂直同步设置
+Mipmap Bias = 贴图 Mipmap 偏移 (锐度修正)
+Anisotropic Filtering = 各向异性过滤 (AF)
+Keybinds = 快捷键绑定 (Keybinds)
+FPS Overlay = 帧率与性能监控悬浮窗
+Menu Theme and Color = 菜单外观主题与配色
+Logging = 日志记录与诊断
+Advanced Settings = 系统底层高级设置
+Magnifier = 画面局部放大镜 (像素检查)
+Save Config = 保存当前配置
+Reload Config = 重新加载配置
+Reset to Defaults = 恢复默认设置
+
+# === 通用菜单标题 ===
+Upscalers = 超分引擎
+Dx11 with Dx12 Settings = DX11 转 DX12 设置
+Vulkan with Dx12 Settings = Vulkan 转 DX12 设置
+XeSS Settings = XeSS 设置
+FFX Settings = FFX 设置
+FSR 3 Upscaler Manual Tuning = FSR 3 超分手动调优
+DLSSD Settings = DLSS 光线重建设置
+DLSS Settings = DLSS 设置
+Frame Generation (FSR FG) = 帧生成（FSR FG）
+Frame Generation (XeFG) = 帧生成（XeFG）
+Frame Generation (DLSSG) = 帧生成（DLSSG）
+Active DispatchFlags = 当前调度标志
+FSR Common Settings = FSR 通用设置
+FoV & Camera Values = 视野与相机参数
+Framerate = 帧率
+VRR Frame Cap Calculator = VRR 帧率上限计算器
+Low Latency = 低延迟
+Sharpness = 锐度
+Advanced DA Parameters = DA 高级参数
+Motion Adaptive Sharpness##2 = 运动自适应锐化
+Upscale Ratio Override = 超分倍率覆盖
+Output Scaling = 输出缩放
+Init Flags = 初始化标志
+Advanced Init Flags = 高级初始化标志
+Active Quirks = 已启用的游戏兼容修正
+DRS (Dynamic Resolution Scaling) = DRS（动态分辨率缩放）
+Resource Barriers = 资源屏障
+Root Signatures = 根签名
+Accent Colour = 强调色
+Background Colour = 背景色
+
+# === 通用按钮、选项和快捷键 ===
+Auto = 自动
+Auto (%3.1f) = 自动（%3.1f）
+Unknown = 未知
+Unbound = 未绑定
+Menu = 菜单
+Menu Scale = 菜单缩放
+Save Settings = 保存设置
+Close = 关闭
+Open Wiki = 打开 Wiki
+Open Wiki (?) = 打开 Wiki (?)
+Open release page = 打开版本发布页
+Update available: %s (current %s) = 发现新版本：%s（当前 %s）
+FPS Overlay Cycle = 切换性能悬浮窗模式
+Neural Rendering = 神经渲染
+Press any key... = 请按下要绑定的按键……
+Key combinations are currently NOT supported! = 暂不支持组合键！
+Escape to cancel, Backspace to unbind = 按 Esc 取消，按 Backspace 解除绑定
+Reset = 重置
+Use master = 使用主设置
+DEFAULT = 默认
+Latest = 最新
+Whatever the game uses = 使用游戏指定的设置
+Latest supported by the dll = 使用当前 DLL 支持的最新预设
+None = 无
+None (Off) = 无（关闭）
+Color = 颜色
+Depth = 深度
+Motion = 运动矢量
+Exposure = 曝光
+Mask = 蒙版
+Output = 输出
+DLAA Preset = DLAA 预设
+UltraQ Preset = 超高质量预设
+Quality Preset = 质量预设
+Balanced Preset = 平衡预设
+Perf Preset = 性能预设
+UltraP Preset = 超高性能预设
+Which copium do you choose? = 选择要使用的超分引擎。
+Affects both FSR-FG & Upscalers = 同时影响 FSR 帧生成与超分。
+This setting will become active on next boot! = 此设置将在下次启动游戏时生效。
+Please select %s as upscaler from game\noptions and load a save game to enable Opti settings.\nUpscalers don't always work in menus. = 请在游戏设置中选择 %s 作为超分引擎，\n进入游戏或读取存档后即可启用 OptiScaler 设置。\n部分游戏不会在菜单中运行超分。
+Can't find nvngx.dll and libxess.dll and FSR inputs\nUpscaling support will NOT work. = 未找到 nvngx.dll、libxess.dll 或 FSR 输入。\n超分功能无法使用。
+%s is active, but not currently used by the game\nPlease enter the game = %s 已启用，但游戏目前未使用它。\n请进入游戏画面。
+Click to open the OptiScaler Wiki page\nin your default browser\n\nCompatibility list with known game issues\nand workarounds, FG options explained\nand other useful info = 在默认浏览器中打开 OptiScaler Wiki。\n\n其中包含游戏兼容性列表、已知问题及解决方法、\n帧生成选项说明和其他实用信息。
+
+# === 神经渲染故障说明 ===
+Not enough graphics memory. Reduce layers or model resolution, then retry. = 显存不足。请减少层数或降低模型工作分辨率，然后重试。
+Not enough memory for more layers. Reduce layers, then retry. = 内存不足，无法增加层数。请减少层数后重试。
+A neural rendering layer could not start. Reduce layers or model resolution, then retry. = 某一神经渲染层无法启动。请减少层数或降低模型工作分辨率，然后重试。
+A neural rendering layer stopped. Reduce layers or change its settings, then retry. = 某一神经渲染层已停止。请减少层数或调整该层设置，然后重试。
+Layer settings need the normal rendering path. Turn off UseProxy in the configuration. = 独立层设置需要标准渲染路径。请在配置文件中关闭 UseProxy。
+The neural rendering image could not be composed. Retry to rebuild it. = 无法合成神经渲染画面。请重试以重新创建所需资源。
+
+# === 多层级联与独立参数（当前界面） ===
+Passes (layers) = 级联叠加层数
+Inherited from master = 继承主设置
+Use master for this layer = 本层全部恢复为主设置
+Layer page = 层设置页码
+Layers %u-%u of %u = 第 %u-%u 层（共 %u 层）
+Layer %u settings = 第 %u 层设置
+Model (master settings) = 模型主设置
+Shared by every layer unless that field has an individual override. = 各层共用以下参数；已单独覆盖的字段除外。
+Unchanged fields follow the master settings. Use master clears only that field; use master for this layer clears all its overrides. = 未修改的字段会跟随主设置。“使用主设置”仅清除该字段的覆盖值；“本层全部恢复为主设置”清除这一层的全部覆盖值。
+Only eight layer panels are shown at a time. This does not limit the number of rendering layers. Ctrl+click the page number to jump to a page. = 每页最多显示八个层设置面板，不限制实际渲染层数。按住 Ctrl 点击页码即可直接输入并跳转。
+Stacks Neural Rendering layers in sequence. 1 is the original single-layer baseline; 2-3 is recommended. Higher counts cost more GPU time and memory and can amplify artifacts. Ctrl+click to type a higher layer count. Changes apply when you finish editing. = 将神经渲染逐层级联叠加。1 层保持原有单层效果；日常推荐 2-3 层。更多层会增加 GPU 耗时和显存占用，也可能放大瑕疵。按住 Ctrl 点击数值可输入更高层数；完成编辑后生效。
+1: baseline | 2-3: recommended | Higher: heavier GPU and memory use = 1 层：原始基准 | 2-3 层：推荐 | 更多层：增加 GPU 与显存负担
+Off by default: every layer uses the master settings. Enable to override selected fields for each layer. Turning this off keeps your overrides but does not apply them. = 默认关闭，所有层共用主设置。开启后可分别覆盖每层的部分参数。再次关闭时会保留独立设置，但暂不应用。
+Native Vulkan uses one layer and the master settings. Multiple layers and individual layer settings require D3D12, including D3D12 bridges. = 原生 Vulkan 仅运行一层并使用主设置。多层级联与独立层设置需要 D3D12，也支持通过 D3D12 桥接的渲染路径。
+Idle: Neural Rendering is off. = 神经渲染已关闭。
+Neural Rendering could not run. The original image is shown. = 神经渲染暂时无法运行，当前显示原始画面。
+Reason: %s = 原因：%s
+Retry = 重试
+Preparing one-layer native Vulkan rendering; waiting for an upscaled frame. = 正在准备原生 Vulkan 单层渲染，等待超分画面输入。
+Preparing Neural Rendering; waiting for an upscaled frame. = 正在准备神经渲染，等待超分画面输入。
+Running: 1 layer on native Vulkan - %.2f ms per frame = 当前运行：原生 Vulkan 单层，每帧 %.2f 毫秒
+Running: 1 layer on native Vulkan = 当前运行：原生 Vulkan 单层
+Running: %u layer(s) - %.2f ms per frame = 当前运行：%u 层叠加，每帧 %.2f 毫秒
+Running: %u layer(s) = 当前运行：%u 层叠加
+The model is running, but its edit is hidden. = 模型正在运行，但效果已隐藏，当前显示原始画面。
+The whole cascade: every model layer, the staging copies and the final composition. Compare this with the frame time at the bottom of the window to see the performance cost. = 此耗时包含完整级联流程：所有模型层、临时图像复制和最终合成。可与窗口底部的总帧时间对比，了解性能开销。
+
+# === 模型主参数与画质选项 ===
+Model preset = 模型预设
+Model resolution = 模型工作分辨率
+Default = 默认
+Preset 1 = 预设 1
+Preset 2 = 预设 2
+Preset 3 = 预设 3
+Default (standard) = 默认（标准）
+Natural = 自然
+Cinematic = 电影感
+Auto skin mask = 自动皮肤蒙版
+Reset##detail = 重置
+Reset##colour = 重置
+Downscaler (NR) = 神经渲染降采样器
+Bicubic = 双三次
+Classic = 经典
+Matched residual = 匹配残差
+Enlargement = 放大方式
+Reversible proxy (experimental) = 可逆代理曲线（实验性）
+Off (soft knee) = 关闭（柔和拐点）
+Neutwo proxy + composed = Neutwo 代理 + 合成
+Neutwo proxy + replace = Neutwo 代理 + 替换
+Hybrid proxy + composed = 混合代理 + 合成
+Hybrid proxy + replace = 混合代理 + 替换
+Supersampling %.2fx: the model runs ABOVE native, then\nis sampled back down. Experimental, and costly -- time grows with the area. = 超采样 %.2fx：模型以高于原生的分辨率运行，\n再降采样输出。这是实验性选项，耗时随像素面积增长。
+Synthesises detail in the upscaler's output, before frame generation sees it.\n\nNeeds two similarly named files beside OptiScaler, one character apart:\n  nvngx_dlssnr.dll       NVIDIA's model (~165 MB) -- you supply it\n  nvngx.dll_dlssnr.dll   the forwarder (~13 KB) -- ships in this package\nUndocumented and driven directly, so none of this is officially supported. = 在超分输出画面上生成细节，然后再交给帧生成。\n\n需要将两个名称相近的文件放在 OptiScaler 旁边：\n  nvngx_dlssnr.dll：NVIDIA 模型（约 165 MB），需自行提供。\n  nvngx.dll_dlssnr.dll：转发器（约 13 KB），随本包附带。\n此接口未公开文档，采用直接调用方式，不属于官方支持功能。
+Whether the model's edit is applied. Off shows the clean upscaler frame while the\npass keeps running -- so with Hold frame (under Compare) you can freeze a\nframe and toggle this to see the same frozen frame with and without Neural\nRendering. Leave it on for normal use. = 控制是否将模型效果应用到画面。关闭时显示未经神经渲染修改的超分画面，但模型仍继续运行。\n可配合“画面对比”中的“冻结当前帧”，切换本项以比较同一帧应用效果前后的差异。日常使用请保持开启。
+Default leaves the choice to the model.\n\nNot the same scale as the super resolution or ray reconstruction presets --\nthe same number means something different here. = 默认选项由模型自行决定。\n\n此处预设与超分或光线重建的预设不同，即使编号相同，含义也不同。
+The model's own processing profiles.\n\nDefault (standard): the strongest. Boosts local contrast and deepens\nlighting, and can oversaturate or look stylised -- most of what reads as\n'the model changed my game's look' is this profile.\n\nNatural: the same detail work with a gentler hand. Keeps skin tones and\ntonal balance closer to what the game rendered.\n\nCinematic: tones down the shine and over-processing for a film-like look.\n\nRead when the model is built, so a change rebuilds it after a moment. The\nnames come from community testing; NVIDIA ships no names in the binaries. = 模型自身的处理风格。\n\n默认（标准）：效果最强，提高局部对比并加深光照，也可能出现过饱和或风格化效果；明显改变游戏观感的通常是此项。\n\n自然：保留细节处理，但力度更温和，使肤色与明暗平衡更接近游戏原画面。\n\n电影感：减弱高光与过度处理，呈现更接近电影的观感。\n\n这些参数在模型创建时读取，修改后会稍候重建。名称来自社区测试，并非 NVIDIA 官方命名。
+The model's own strength control, applied inside it. Distinct from detail\nstrength above, which scales the result afterwards. = 控制模型内部的处理强度。与上方“细节强度”不同，后者调整的是模型结果的最终应用力度。
+-1 means follow local structure, and is the model's own default -- it is not a\nstrength of zero. 0 and above set skin independently of the rest of the frame. = -1 表示跟随局部结构，是模型自身的默认值，并不代表强度为零。设为 0 或更高时，皮肤细节将独立于画面其他部分调整。
+Lets the model find skin itself rather than treating the frame uniformly. = 由模型自动识别皮肤区域，而不是对整幅画面一视同仁地处理。
+
+# === 放大镜、日志与性能悬浮窗 ===
+Enable Magnifier = 启用放大镜
+Size = 大小
+%.1f%% of screen = 屏幕的 %.1f%%
+%.2f%% of screen = 屏幕的 %.2f%%
+Zoom Factor = 放大倍率
+Border Size = 边框宽度
+Positioning = 位置设置
+Static Pos X = 固定位置 X
+Static Pos Y = 固定位置 Y
+Reset Static Position (Follow Cursor) = 重置固定位置（跟随光标）
+Set Static Position = 设置固定位置
+(Currently following cursor) = （当前跟随光标）
+Cursor Offset X = 光标偏移 X
+Cursor Offset Y = 光标偏移 Y
+Enable Extended Limits = 放宽参数范围
+Use Precompiled Shaders = 使用预编译着色器
+Override Minimum = 覆盖最小值
+Override Maximum = 覆盖最大值
+Restore Compute Root Signature = 恢复计算根签名
+Restore Graphic Root Signature = 恢复图形根签名
+Fix for games ignoring official DRS limits = 修正部分游戏忽略官方动态分辨率范围的问题。
+Extended sliders limit for quality presets\n\nUsing this option changes resolution detection logic\nand might cause issues and crashes! = 放宽画质预设滑块的取值范围。\n\n此选项会改变分辨率检测逻辑，可能导致兼容性问题或崩溃！
+To File = 输出到文件
+To Console = 输出到控制台
+Log Level = 日志级别
+Trace = 跟踪
+Debug = 调试
+Information = 信息
+Warning = 警告
+Error = 错误
+Light Theme = 浅色主题
+Presets: = 预设：
+Reset Accent Color = 重置强调色
+FPS Overlay Enabled = 启用性能悬浮窗
+Horizontal = 横向布局
+Overlay Position = 悬浮窗位置
+Top Left = 左上
+Top Right = 右上
+Bottom Left = 左下
+Bottom Right = 右下
+Overlay Type = 悬浮窗类型
+Just FPS = 仅帧率
+Simple = 简洁
+Detailed = 详细
+Detailed + Graph = 详细 + 曲线图
+Full = 完整
+Full + Graph = 完整 + 曲线图
+Reflex timings = Reflex 延迟明细
+Background Alpha = 背景不透明度
+Same as menu = 跟随菜单
+Scale = 缩放
+Use Theme Colors = 使用主题颜色
+Use Fsr2 Inputs = 使用 FSR 2 输入
+Use Fsr2 Pattern Matching = 使用 FSR 2 特征匹配
+Use Fsr3 Inputs = 使用 FSR 3 输入
+Use Fsr3 Pattern Matching = 使用 FSR 3 特征匹配
+Use Ffx Inputs = 使用 FFX 输入
+
+# === 色彩、曝光扫描与画面对比 ===
+Enter a whole number from 1 to %u. = 请输入 1 到 %u 之间的整数。
+The model was trained on finished, sRGB-encoded frames. The upscaler's\noutput is not one: it is linear and open-ended. These decide how it is\nmapped into something the model recognises. A frame the game reports as\nalready tone-mapped is passed over untouched and none of this applies. = 模型使用已完成色调映射的 sRGB 画面训练，而超分输出是没有固定上限的线性画面。\n以下选项决定如何将其映射为模型能够识别的图像。\n游戏标记为已完成色调映射的画面会原样通过，不受这些选项影响。
+Paper white only = 仅使用手动纸白
+The game's own exposure = 游戏原生曝光
+A buffer the scan found = 扫描找到的曝光缓冲区
+White point from = 白点来源
+Waiting for a frame... = 等待画面输入……
+This game supplies no exposure -- paper white is in use. Try the scan instead. = 游戏未提供曝光数据，当前使用手动纸白。可尝试改用扫描。
+This game supplies an exposure and it is being read. = 游戏已提供曝光数据，正在读取。
+Game exposure %.4f  ->  white point %.2f%s = 游戏曝光 %.4f → 白点 %.2f%s
+\s\s(held: absent this frame) = \s\s（本帧未提供，沿用上次值）
+Reading the exposure... = 正在读取曝光……
+Nothing in this game is shaped like an exposure. = 尚未找到形态符合曝光数据的缓冲区。
+Watching %u, none moving yet -- go between light and shade. = 正在观察 %u 个候选项，尚无变化。请在明暗场景之间移动。
+Found one. Set paper white below until the picture looks right, then press Anchor here. = 已找到候选项。请先调整下方纸白至画面合适，再点击“在此添加校准点”。
+This game supplies an exposure -- the option above would use it. = 游戏提供了原生曝光，可通过上方选项使用。
+Scan %.5f  ->  white point %.2f   (%u calibration points) = 扫描值 %.5f → 白点 %.2f（%u 个校准点）
+Paper white (editing point %d) = 纸白（正在编辑校准点 %d）
+Trim (x the scan) = 扫描白点微调倍率
+Reset##scantrim = 重置
+Reset##wptrim = 重置
+Highlight guard = 高光保护
+Reset##guard = 重置
+Show the light meter on screen = 在画面上显示亮度指示器
+Anchor here = 在此添加校准点
+(the scan is only watching -- the white point above comes from somewhere else) = （扫描仅用于观察；当前白点来自其他来源）
+%s scan %.4f  ->  white %.2f%s = %s 扫描值 %.4f → 白点 %.2f%s
+\s\s\s[editing] = \s\s\s[编辑中]
+Click a row to edit it with the slider above; click it again to control the live point. > is the point in use now. = 点击一行可用上方滑块编辑该校准点；再次点击恢复实时调整。“>”表示当前使用的校准点。
+The number runs the other way = 数值变化方向相反
+Advanced = 高级
+nothing matched yet. = 尚未找到匹配项。
+%zu. %s -- not read yet = %zu. %s — 尚未读取
+%zu. %s \= %.5f  (seen %.5f..%.5f) %s = %zu. %s = %.5f（已观察范围 %.5f..%.5f）%s
+MOVES = 正在变化
+flat so far = 暂无变化
+Walk from shade into daylight. A real exposure moves. = 请从阴影走到日光下；真正的曝光值应该随之变化。
+One that only ever climbs is a counter, not an exposure. = 只会持续增大的值是计数器，并非曝光。
+Off = 关闭
+Swap sides = 交换左右画面
+Label the sides = 显示左右画面标签
+Label size = 标签大小
+Zoom = 缩放
+Split = 分割位置
+Proxy (what the model sees) = 代理图像（模型输入）
+Model output (raw) = 模型原始输出
+Difference (amplified) = 差异图（放大显示）
+DLSS NR : ON = DLSS 神经渲染：开启
+DLSS NR : OFF = DLSS 神经渲染：关闭
+Where the number that divides the frame comes from.\n\nPaper white only -- the slider below and nothing else. Right for a\ngame whose exposure never moves, wrong the moment it does: one\nconstant cannot serve a cave and a field.\n\nThe game's own exposure -- read from the texture the game hands\nthe upscaler. The best source there is, because it is decided\nupstream and nothing this pass does can move it. Not every game\nsupplies one.\n\nA buffer the scan found -- for games that compute an exposure and\nnever pass it on. A GUESS: candidates are matched by shape, and in\nGTA V the best one tracks the real exposure but at its own scale,\nwhich the anchor's ratio cancels. Needs anchoring once, and checking\nafterwards. = 选择画面归一化时使用的白点来源。\n\n仅使用手动纸白：完全由下方滑块决定。适合曝光不变化的游戏；固定值很难同时适应洞穴与日光场景。\n\n游戏原生曝光：读取游戏交给超分器的曝光纹理。这通常是最可靠的来源，因为它由上游决定，不受神经渲染影响；但并非所有游戏都会提供。\n\n扫描找到的曝光缓冲区：适用于内部计算曝光却未传给超分器的游戏。候选项只是根据形态推测，数值比例可能不同，需要手动添加校准点，并检查跟踪是否可靠。
+The white point for the selected calibration point, or -- with no row\nselected -- the value the next Anchor press captures.\n\nSet it until the picture looks right here, then Anchor. Move to very\ndifferent light and do it again: two points fix the buffer's real\nrelationship and the white point holds between them. Click a row below\nto come back and adjust that point; click it again to let go. = 调整选中校准点的白点；未选中任何行时，则设置下一次添加校准点时记录的数值。\n\n先调到画面合适，再添加校准点。移动到光照差异较大的位置并再次校准，可用两个点确定缓冲区与白点的关系。点击下方一行即可重新编辑，再次点击取消选择。
+A multiplier on the scan's white point, and the control you adjust between\nanchor points: dial it until the picture looks right in the current\nlight, then press Anchor here -- it captures the trimmed value as a new\npoint and resets the trim to 1. = 对扫描白点施加倍率微调。请在当前光照下调到画面合适，再点击“在此添加校准点”。新校准点会记录微调后的结果，随后倍率自动恢复为 1。
+A multiplier on the exposure the game supplied. 1.00x takes its number\nexactly, and that is the right answer here.\n\nThis is not a fudge factor. If a game needs the trim far from 1 to look\nright, that is evidence the exposure being read is wrong for that game,\nnot that the game wants trimming. Somewhere around 0.8 to 1.25 is honest\ntuning; reaching for 4 means something upstream is broken and the trim is\nhiding it.\n\nYour manual paper white is kept separately and comes back untouched if\nyou switch the option above off. = 对游戏提供的曝光施加倍率。1.00x 表示完全采用原值，通常应从这里开始。\n\n如果必须大幅偏离 1 才能使画面正常，可能是读取到的曝光不适合该游戏，而不只是偏好差异。约 0.8 到 1.25 属于合理微调；需要调到 4 时应先检查上游问题。\n\n手动纸白单独保存，切回手动来源时会原样恢复。
+The most the pass may move any pixel, as a multiple of what it already was, in\nboth directions -- a pixel may not be brightened past this nor darkened past\nits reciprocal. Lights are where the model has least to say and rescaling its\nanswer does the most damage; 2x leaves detail intact while stopping a strip\nlight turning into a string of coloured cells. Raise it only if bright areas\nlook clipped. = 限制单个像素相对原值的亮度变化倍率，双向生效：变亮不超过此倍率，变暗不低于其倒数。\n\n2x 通常可保留细节，同时防止灯带等高光出现彩色块状瑕疵。仅在明亮区域的效果明显受限时再提高。
+Flip this if the picture gets worse in the direction it should be\ngetting better. Most engines store an exposure that falls as\nthe scene brightens; some store its reciprocal, and a buffer\nfound by shape does not say which. Add a second anchor point in\ndifferent light and this is decided for you, so it disappears. = 如果光照变化时画面朝错误方向变化，可切换此项。多数引擎的曝光值随场景变亮而降低，也有引擎保存其倒数，仅靠缓冲区形态无法区分。\n\n添加第二个不同光照的校准点后，变化方向由校准数据自动决定，此选项将隐藏。
+Freezes the frame the model works on. While held, change paper white, the\nstrengths, the reversible mode, the model preset -- anything below the\nupscaler -- and only that setting moves; the scene does not.\n\nWhat it CANNOT show: DLSS/FSR/XeSS upscaler presets or anything upstream\n(the upscaler is not re-run on a held frame), and the game's own HUD and\npost-processing, which run after this pass and keep updating. The white\npoint stops being measured and holds its value while frozen, so it cannot\ndrift and confound the comparison.\n\nHide the menu and it stays held. Untoggle to resume. = 冻结交给模型处理的画面。冻结期间可调整纸白、强度、可逆模式或模型预设，场景保持不动，仅观察参数变化。\n\n无法用于比较 DLSS/FSR/XeSS 超分预设或其他上游设置，因为冻结帧不会重新运行超分。游戏 HUD 与后处理位于神经渲染之后，仍可能继续更新。白点测量也会暂停并保持原值，避免干扰对比。\n\n隐藏菜单后仍保持冻结；关闭本项即可恢复。
+Shows the pass against itself, so the two can be seen at once rather than\ntoggled and remembered.\n\nSide by side puts the whole frame in each half, untouched on the left and\nedited on the right. Both halves are squeezed horizontally to fit, so it is\nfor looking at rather than playing in.\n\nWipe cuts a single frame at the split and resamples nothing, so the picture\nis the right shape and can be played normally. Drag the split below; it is a\nstored setting and stays put once the menu is closed.\n\nNeither needs the menu open to keep working. A hairline marks the join. = 同时显示原始画面与神经渲染结果，无需依靠切换前后的记忆。\n\n左右并排：左侧为原始画面，右侧为处理后画面；完整画面分别放入半屏，主要用于观察。\n\n卷帘对比：按分割线显示同一画面的两种结果，不重新采样，画面比例正常，可正常游玩。下方分割位置会保存，关闭菜单后仍生效。\n\n两种模式都无需保持菜单打开，接缝由细线标示。
+Where the wipe cuts. Left of it is the frame as the upscaler produced it,\nright of it is the frame the model edited. = 调整卷帘分割线。默认左侧为超分原始输出，右侧为模型处理后的画面。
+Proxy is the picture handed to the model -- if that looks wrong, the white point\nis wrong and nothing downstream can be judged.\n\nDifference shows what the model actually changed, amplified twenty times and\ncentred on grey. A flat grey frame there means it is doing nothing. = 代理图像是模型实际接收到的输入。如果它看起来不正常，应先检查白点，不能据此判断后续效果。\n\n差异图将模型修改放大二十倍，并以灰色为零点。整幅画面均为灰色表示模型没有产生变化。


### PR DESCRIPTION
Runs the DLSS neural-rendering model more than once over the same frame on D3D12. Each extra pass is a separate NGX feature with its own frame history, fed the previous pass's answer, so later passes see one frame per frame instead of re-feeding one instance's own output. The pass count is not capped at a product number: 2-3 is the sensible range, the UI suggests 1-6, and a direct numeric input accepts any positive uint32_t. Off by default: [DlssNr] Passes=1 and IndividualPassSettings=false take the same path the code takes today (one evaluate with identical arguments; no scratch, no extra features, no chain).

This is an independent implementation on the same base as #23 (and alongside the draft in #1). The machinery is necessarily close family — separate per-pass features built a frame ahead so nothing is created and evaluated on one command list, a two-texture work set, modelInput left untouched so the resolve's edit = model - proxy stays the whole chain's. Where it differs: no fixed upper bound (extra features are created one per Dispatch, one at a time, and every build frame returns before evaluation); sparse per-layer overrides with live master inheritance; and the menu shows the count that actually completed (DlssNr::ActivePassCount()), not the requested one. If you would rather keep one multipass implementation in the tree I am happy to reconcile or rebase this onto whichever you pick.

## Per-pass sparse configuration

[DlssNr] IndividualPassSettings=false by default: every layer uses the master model controls and nothing is copied or materialised. Setting it true does not snapshot the master values — each [DlssNr.PassN] section stores only the fields actually overridden; everything else keeps inheriting the master settings live. Sections are 1-based, may skip numbers, and lowering Passes never deletes higher overrides. On save the owned sections are rebuilt from the in-memory map so cleared fields and alternate spellings (Pass01) cannot resurrect stale keys. Override-map reads/writes are guarded by a dedicated mutex (the render side only looks up, never inserts).

## Pipeline notes

- Extra features live in a dynamic vector; [0] is pass 2 by the renderer's counting (config uses 1-based pass numbers; the conversion is explicit at the single integration point).
- Work textures: the existing output plus outputPingPong, allocated only when Passes > 1; passes alternate UAV/SRV ownership as they read the previous answer and write the next. finalOutput is tracked by pointer, never re-derived from parity at resolve time.
- A pass whose settings changed is rebuilt; changing the upstream count or resolution resets the chain's history rather than recreating every downstream instance blindly.
- A failed extra pass stops the chain at the last good surface, latches a reason shown in the menu (with Retry); lowering the count clears the latch — no per-frame reallocation/retry storm.
- Native Vulkan keeps today's single-pass master behaviour; the menu says so instead of showing controls that would not apply. The DlssNrUseProxy path does not participate in the chain or per-pass overrides and is refused with an explanation.

## Localization (self-contained; drop the last commit to remove entirely)

Optional, non-invasive Chinese language pack. English source text remains the key; Localization::Tr() looks up a UTF-8 dictionary (OptiScaler_zh.ini / zh_CN.ini next to the DLL, then beside the game exe) loaded once per DLL lifetime; missing files or keys fall back to the original English text, and translations that do not preserve every printf directive or that alter ImGui ##/### identity suffixes are rejected at load. When the pack is in use, the menu font atlas merges %WINDIR%\Fonts\msyh.ttc (resolved via GetWindowsDirectoryW) so CJK glyphs render instead of boxes. Without the pack nothing changes: no dictionary, no font merge, no behavioural delta.

All C++/H follows CONTRIBUTING.md PCH rules (new Localization.cpp includes pch.h first; no header includes it).

## What I did not do

No HLSL/cbuffer or precompiled-shader changes; no NGX forwarder ABI change; no Vulkan multi-pass; no new model DLL; no new GPU queues. No VRAM formula is claimed beyond the host side (one extra work texture; each feature's internal state still grows with the count).

## Test plan

- [x] Release x64 MSBuild builds clean
- [x] D3D12: Passes=1 picture is unchanged from today's build (default-identical path)
- [x] D3D12: 1->2->3 live switching; even/odd final-output parity verified in GTA V Enhanced
- [x] D3D12: per-pass overrides inherit master when IndividualPassSettings=false
- [x] D3D12: menu shows the actually-completed layer count
- [x] zh pack: with OptiScaler_zh.ini present the menu renders Chinese (incl. glyphs); without it the menu is byte-identical English
